### PR TITLE
ci: add Windows debug tests workflow

### DIFF
--- a/.github/workflows/windows-debug-tests.yml
+++ b/.github/workflows/windows-debug-tests.yml
@@ -1,0 +1,42 @@
+name: Windows Debug Tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    env:
+      LIVECAP_FFMPEG_BIN: "${{ github.workspace }}\\ffmpeg-bin"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install FFmpeg
+        shell: pwsh
+        run: |
+          choco install -y ffmpeg
+          New-Item -ItemType Directory -Force -Path ffmpeg-bin | Out-Null
+          $ff = (Get-Command ffmpeg).Source
+          Copy-Item $ff ffmpeg-bin\ffmpeg.exe -Force
+          $fp = (Get-Command ffprobe).Source
+          Copy-Item $fp ffmpeg-bin\ffprobe.exe -Force
+
+      - name: Sync dependencies
+        run: uv sync --extra translation --extra dev
+
+      - name: Run tests
+        run: uv run python -m pytest tests
+

--- a/docs/dev-docs/testing/README.md
+++ b/docs/dev-docs/testing/README.md
@@ -84,6 +84,9 @@ own binaries without committing them.
 - `Integration Tests` workflow: manual or scheduled opt-in that runs the same
   suite with additional extras/models when required and also prepares
   `ffmpeg-bin` for MKV coverage.
+- `Windows Debug Tests` workflow: manual, Windows-only variant of the core test
+  suite that mirrors `pytest tests` on `windows-latest` with `translation`+`dev`
+  extras and a `ffmpeg-bin` directory configured via `LIVECAP_FFMPEG_BIN`.
 
 Keep this document updated whenever the workflows or extras change so local
 developers can reproduce CI faithfully.


### PR DESCRIPTION
## Summary

- Add a dedicated `Windows Debug Tests` GitHub Actions workflow that runs the core test suite on `windows-latest` with Python 3.10/3.11/3.12.
- The workflow installs FFmpeg via Chocolatey, prepares a `ffmpeg-bin` directory, and exposes it via `LIVECAP_FFMPEG_BIN` so the existing MKV regression tests can resolve FFmpeg on Windows.
- Update the testing guide to document the new Windows-only debug workflow and how it mirrors the Ubuntu-based Core Tests.

## Details

- Workflow: `.github/workflows/windows-debug-tests.yml`
  - Trigger: `workflow_dispatch` (manual).
  - Job `tests`:
    - `runs-on: windows-latest` with Python 3.10/3.11/3.12 matrix.
    - Uses `actions/checkout`, `actions/setup-python`, and `astral-sh/setup-uv`.
    - Installs FFmpeg via `choco install -y ffmpeg`, then copies `ffmpeg.exe` / `ffprobe.exe` into `ffmpeg-bin`.
    - Sets `LIVECAP_FFMPEG_BIN` to `${{ github.workspace }}\ffmpeg-bin` so `FileTranscriptionPipeline` and the MKV regression test reuse the same convention as Ubuntu CI.
    - Runs `uv sync --extra translation --extra dev` followed by `uv run python -m pytest tests`.

- Docs: `docs/dev-docs/testing/README.md`
  - Extend the CI mapping section to include the `Windows Debug Tests` workflow as a Windows-only variant of the core test suite.

## Testing

- Locally: `uv run python -m pytest tests/core/cli/test_cli.py` (sanity check around the CLI and test harness).
- Windows workflow will be invoked manually via `workflow_dispatch` once merged to validate on `windows-latest`.

Closes #24.