### PR TITLE
feat: improve CI test visibility with summary and annotations

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,88 @@
+import os
+import sys
+from typing import Any
+
+import pytest
+
+
+def pytest_terminal_summary(terminalreporter: Any, exitstatus: int, config: Any) -> None:
+    """
+    Add a summary of test results to the GitHub Step Summary and output warnings for skips.
+    This hook is executed after all tests have finished.
+    """
+    github_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    
+    # Collect stats from the terminal reporter
+    passed = terminalreporter.stats.get("passed", [])
+    skipped = terminalreporter.stats.get("skipped", [])
+    failed = terminalreporter.stats.get("failed", [])
+    
+    # 1. Output GitHub Actions Warnings for skipped tests
+    # This makes them visible in the run summary and annotations
+    if skipped:
+        for s in skipped:
+            reason = "No reason given"
+            # Robustly retrieve reason from longrepr
+            if hasattr(s, "longrepr"):
+                if isinstance(s.longrepr, tuple) and len(s.longrepr) >= 3:
+                    reason = str(s.longrepr[2])
+                elif isinstance(s.longrepr, str):
+                    reason = s.longrepr
+            
+            # Extract location for annotation
+            # s.location is typically (file_path, line_index, test_name)
+            file_path, line_index, _ = s.location if hasattr(s, "location") else ("unknown", -1, "")
+            
+            # Print annotation command (::warning ...) to stdout
+            # Line number in annotations is 1-based, location index is 0-based
+            print(f"::warning file={file_path},line={line_index + 1}::Test skipped: {s.nodeid} -- {reason}")
+
+    # 2. Write rich summary to GITHUB_STEP_SUMMARY if available
+    if not github_summary:
+        return
+
+    try:
+        with open(github_summary, "a", encoding="utf-8") as f:
+            f.write("## 🧪 Test Execution Summary\n\n")
+            
+            status_icon = "✅" if exitstatus == 0 else "❌"
+            status_text = "Success" if exitstatus == 0 else "Failure"
+            f.write(f"**Status**: {status_icon} {status_text}\n\n")
+            
+            # Summary Table
+            f.write("| Metric | Count |\n")
+            f.write("| --- | ---: |\n")
+            f.write(f"| Passed | {len(passed)} |\n")
+            f.write(f"| Skipped | {len(skipped)} |\n")
+            f.write(f"| Failed | {len(failed)} |\n\n")
+            
+            if failed:
+                f.write(f"### ❌ Failed ({len(failed)})\n")
+                for e in failed:
+                    f.write(f"- **{e.nodeid}**\n")
+                f.write("\n")
+            
+            if skipped:
+                f.write(f"### ⚠️ Skipped ({len(skipped)})\n")
+                for s in skipped:
+                    # Retrieve reason again for markdown report
+                    reason = "No reason given"
+                    if hasattr(s, "longrepr"):
+                        if isinstance(s.longrepr, tuple) and len(s.longrepr) >= 3:
+                            reason = str(s.longrepr[2])
+                        elif isinstance(s.longrepr, str):
+                            reason = s.longrepr
+                    
+                    f.write(f"- **{s.nodeid}**\n  - 📝 `{reason}`\n")
+                f.write("\n")
+
+            if passed:
+                f.write(f"### ✅ Passed ({len(passed)})\n")
+                f.write("<details><summary>Show passed tests</summary>\n\n")
+                for p in passed:
+                    f.write(f"- `{p.nodeid}`\n")
+                f.write("\n</details>\n\n")
+
+    except (OSError, IOError) as e:
+        # Do not fail the build if summary writing fails
+        print(f"Warning: Could not write to GITHUB_STEP_SUMMARY: {e}", file=sys.stderr)


### PR DESCRIPTION
## Summary
Adds a `pytest_terminal_summary` hook in `tests/conftest.py` to improve visibility of test results in GitHub Actions.

## Features
- **Step Summary**: Generates a Markdown summary of test results (Passed/Skipped/Failed) and writes it to `$GITHUB_STEP_SUMMARY`.
- **Annotations**: Emits GitHub Actions Warning annotations (`::warning ...`) for skipped tests, making them visible in the PR diff and summary without digging into logs.

## Implementation Details
- Implemented in `tests/conftest.py` to avoid external dependencies like `pytest-md-report`.
- Robust handling of `longrepr` to extract skip reasons across different pytest versions/configurations.
- Includes a breakdown table and detailed lists for skipped/failed tests.

## Refs
Fixes #39