### PR TITLE
fix: resolve Parakeet CI stability (windows os.uname patch)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -234,13 +234,13 @@ jobs:
               from collections import namedtuple
               UnameResult = namedtuple("UnameResult", ["sysname", "nodename", "release", "version", "machine"])
               def uname():
-                  import platform
+                  # Avoid platform.* calls that might recurse back to os.uname
                   return UnameResult(
                       sysname="Windows",
-                      nodename=platform.node(),
-                      release=platform.release(),
-                      version=platform.version(),
-                      machine=platform.machine()
+                      nodename=os.environ.get("COMPUTERNAME", "unknown"),
+                      release=os.environ.get("OS", "unknown"),
+                      version="10.0.xxxx",
+                      machine=os.environ.get("PROCESSOR_ARCHITECTURE", "AMD64")
                   )
               os.uname = uname
 


### PR DESCRIPTION
## Summary
Fixes the crash in Parakeet engine initialization on Windows caused by `lhotse` calling `os.uname()`.

## Changes
- **Windows GPU Warmup**: Added a monkey-patch for `os.uname()` in the python script. It returns a dummy `posix.uname_result`-like object with sysname='Windows'.
- **Re-enabled Parakeet**: Uncommented `warm('parakeet', ...)` on Windows.

## Refs
Fixes part of #36