### PR TITLE
fix: resolve NeMo import error on Windows by patching os.uname in conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,21 @@ from typing import Any
 
 import pytest
 
+# Monkey-patch os.uname for Windows to support lhotse/NeMo during tests
+if sys.platform == "win32" and not hasattr(os, "uname"):
+    from collections import namedtuple
+    UnameResult = namedtuple("UnameResult", ["sysname", "nodename", "release", "version", "machine"])
+    def uname():
+        # Avoid platform.* calls that might recurse back to os.uname
+        return UnameResult(
+            sysname="Windows",
+            nodename=os.environ.get("COMPUTERNAME", "unknown"),
+            release=os.environ.get("OS", "unknown"),
+            version="10.0.xxxx",
+            machine=os.environ.get("PROCESSOR_ARCHITECTURE", "AMD64")
+        )
+    os.uname = uname
+
 
 def pytest_terminal_summary(terminalreporter: Any, exitstatus: int, config: Any) -> None:
     """


### PR DESCRIPTION
## Summary
Applies the `os.uname()` monkey-patch to `tests/conftest.py` to support Parakeet/NeMo tests on Windows.

## Problem
While the `warmup.py` script was patched in PR #42, the `pytest` execution environment (which runs separately) was not.
When `pytest` imports `parakeet_engine.py`, it transitively imports `lhotse`, which calls `os.uname()` on import, leading to `AttributeError` or `ImportError` on Windows.

## Fix
The same monkey-patch used in the warmup script is now applied in `conftest.py`, ensuring `os.uname()` is available (mocked) during the entire test session.

## Refs
Fixes #36 (Windows import part)