### PR TITLE
optimize: persistent caching for self-hosted runners

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -189,6 +189,21 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v3
 
+      # Restore UV_CACHE_DIR after setup-uv overwrites it with a temp path
+      - name: Restore UV_CACHE_DIR (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          echo "UV_CACHE_DIR=$HOME/LiveCap/Cache/uv" >> $GITHUB_ENV
+          echo "Restored UV_CACHE_DIR to $HOME/LiveCap/Cache/uv"
+
+      - name: Restore UV_CACHE_DIR (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          "UV_CACHE_DIR=C:\LiveCap\Cache\uv" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Host "Restored UV_CACHE_DIR to C:\LiveCap\Cache\uv"
+
       # Removed actions/cache for ffmpeg-bin as we use persistent LIVECAP_FFMPEG_BIN
 
       - name: Check FFmpeg existence (Linux)


### PR DESCRIPTION
## Summary
Implements persistent caching for self-hosted runners to drastically reduce CI time.

## Changes
- **Persistent Paths**: Configures `UV_CACHE_DIR`, `LIVECAP_CACHE_DIR`, and `LIVECAP_FFMPEG_BIN` to point to persistent directories on the runner machine (e.g., `C:\LiveCap\Cache\...` on Windows).
- **FFmpeg Optimization**: Skips `setup-livecap-ffmpeg` download if the binary already exists in the persistent directory.
- **Cache Action Removal**: Removed `actions/cache` for `ffmpeg-bin` as it is redundant on self-hosted runners.

## Refs
Fixes #38