### PR TITLE
fix: correct environment variables for persistent model caching

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -188,13 +188,13 @@ jobs:
           # Ensure directories exist
           New-Item -ItemType Directory -Force -Path "$cacheRoot\uv" | Out-Null
           New-Item -ItemType Directory -Force -Path "$cacheRoot\models" | Out-Null
-          New-Item -ItemType Directory -Force -Path "$cacheRoot\huggingface" | Out-Null
+          New-Item -ItemType Directory -Force -Path "$cacheRoot\cache" | Out-Null
           New-Item -ItemType Directory -Force -Path "$cacheRoot\ffmpeg-bin" | Out-Null
           
           # Set Environment Variables
           "UV_CACHE_DIR=$cacheRoot\uv" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "LIVECAP_CACHE_DIR=$cacheRoot\models" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "HF_HOME=$cacheRoot\huggingface" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "LIVECAP_CORE_MODELS_DIR=$cacheRoot\models" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "LIVECAP_CORE_CACHE_DIR=$cacheRoot\cache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "LIVECAP_FFMPEG_BIN=$cacheRoot\ffmpeg-bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           
           Write-Host "Configured persistent paths at $cacheRoot"
@@ -208,13 +208,13 @@ jobs:
           # Ensure directories exist
           mkdir -p "$CACHE_ROOT/uv"
           mkdir -p "$CACHE_ROOT/models"
-          mkdir -p "$CACHE_ROOT/huggingface"
+          mkdir -p "$CACHE_ROOT/cache"
           mkdir -p "$CACHE_ROOT/ffmpeg-bin"
           
           # Set Environment Variables
           echo "UV_CACHE_DIR=$CACHE_ROOT/uv" >> $GITHUB_ENV
-          echo "LIVECAP_CACHE_DIR=$CACHE_ROOT/models" >> $GITHUB_ENV
-          echo "HF_HOME=$CACHE_ROOT/huggingface" >> $GITHUB_ENV
+          echo "LIVECAP_CORE_MODELS_DIR=$CACHE_ROOT/models" >> $GITHUB_ENV
+          echo "LIVECAP_CORE_CACHE_DIR=$CACHE_ROOT/cache" >> $GITHUB_ENV
           echo "LIVECAP_FFMPEG_BIN=$CACHE_ROOT/ffmpeg-bin" >> $GITHUB_ENV
           
           echo "Configured persistent paths at $CACHE_ROOT"


### PR DESCRIPTION
## Summary
Corrects the environment variable names used for model caching to match the `ModelManager` implementation.

## Changes
- **Environment Variables**:
    - `LIVECAP_CACHE_DIR` -> `LIVECAP_CORE_MODELS_DIR`
    - Added `LIVECAP_CORE_CACHE_DIR`
    - Removed `HF_HOME` (managed automatically by `ModelManager` via `LIVECAP_CORE_CACHE_DIR`)
- **Directories**: Updated creation steps to create `cache` instead of `huggingface`.

## Impact
This ensures that models are actually cached in the persistent directory on self-hosted runners, rather than falling back to the default user cache directory (which was coincidentally persistent but not controlled).

## Refs
Fixes issue identified in optimization review.