### PR TITLE
docs: fix LIVECAP_CORE_*_DIR default paths in testing README

### DIFF
--- a/docs/dev-docs/testing/README.md
+++ b/docs/dev-docs/testing/README.md
@@ -93,8 +93,8 @@ uv run python -m pytest tests/core/engines
 | `LIVECAP_FFMPEG_BIN` | FFmpeg/FFprobe バイナリのディレクトリパス | 自動検出 |
 | `LIVECAP_ENABLE_GPU_SMOKE` | `1` で GPU スモークテストを有効化 | 未設定（skip） |
 | `LIVECAP_REQUIRE_ENGINE_SMOKE` | `1` でエンジンスモーク失敗時に skip ではなく fail | 未設定（skip） |
-| `LIVECAP_CORE_MODELS_DIR` | モデルキャッシュの保存先 | `~/.livecap/models` |
-| `LIVECAP_CORE_CACHE_DIR` | 一時キャッシュの保存先 | `~/.livecap/cache` |
+| `LIVECAP_CORE_MODELS_DIR` | モデルキャッシュの保存先 | `appdirs.user_cache_dir("LiveCap", "PineLab")/models`（Linux: `~/.cache/LiveCap/PineLab/models`、Windows: `%LOCALAPPDATA%\PineLab\LiveCap\Cache\models`） |
+| `LIVECAP_CORE_CACHE_DIR` | 一時キャッシュの保存先 | `appdirs.user_cache_dir("LiveCap", "PineLab")/cache`（Linux: `~/.cache/LiveCap/PineLab/cache`、Windows: `%LOCALAPPDATA%\PineLab\LiveCap\Cache\cache`） |
 
 ### Self-hosted ランナーの永続キャッシュパス
 


### PR DESCRIPTION
## Summary
- `LIVECAP_CORE_MODELS_DIR` / `LIVECAP_CORE_CACHE_DIR` のデフォルト値を実装に合わせて修正

## 修正内容
`ModelManager` は `appdirs.user_cache_dir("LiveCap", "PineLab")` を使用：
- **Linux**: `~/.cache/LiveCap/PineLab/{models,cache}`
- **Windows**: `%LOCALAPPDATA%\PineLab\LiveCap\Cache\{models,cache}`

`~/.livecap/...` は `appdirs` が無い場合のフォールバックのみ。

参照: `livecap_core/resources/model_manager.py:60-70`

Closes #60 のレビュー指摘

🤖 Generated with [Claude Code](https://claude.com/claude-code)