### PR TITLE
docs: add refactoring plan and reorganize docs structure

### DIFF
--- a/docs/planning/refactoring-plan.md
+++ b/docs/planning/refactoring-plan.md
@@ -1,0 +1,537 @@
+# LiveCap Core リファクタリング計画
+
+> **作成日:** 2025-11-25
+> **ステータス:** 計画中
+> **関連:** [feature-inventory.md](../reference/feature-inventory.md)
+
+---
+
+## 1. 背景と目的
+
+### 1.1 本リポジトリの目的
+
+**可能な限り高速なリアルタイム文字起こしを、CLIでユーザーに提供すること。**
+
+そのために：
+- モデルのロード効率化
+- 文字起こし（VAD含む）の効率化
+- 低レイテンシなストリーミング処理
+
+### 1.2 現状の課題
+
+現在の設計は LiveCap-GUI からの分離抽出という経緯から、以下の問題を抱えている：
+
+| 課題 | 影響度 | 詳細 |
+|------|--------|------|
+| リアルタイム文字起こし未実装 | 致命的 | 本来の目的機能が存在しない |
+| パッケージ境界の不整合 | 高 | `engines/`, `config/` が分散 |
+| API の二重構造 | 高 | イベント型とセグメント型が混在 |
+| Config の肥大化 | 中 | GUI 由来の不要パラメータ |
+| BaseEngine の過剰な複雑さ | 中 | GUI 向け6段階フェーズ管理 |
+| 翻訳機能の未実装 | 中 | 型定義のみで実装なし |
+| 依存関係の重さ | 中 | 基本インストールが重い |
+
+---
+
+## 2. リファクタリング方針
+
+### 2.1 設計原則
+
+1. **リアルタイム優先**: ストリーミング処理を第一級市民として設計
+2. **ハードウェア抽象化**: コアは `np.ndarray` を受け取り、デバイス管理は外部
+3. **プラグイン拡張性**: エンジン・翻訳サービスの追加が容易
+4. **最小依存**: 基本機能は軽量、重い依存はオプショナル
+5. **単一責務**: GUI 固有の機能はコアに含めない
+
+### 2.2 ターゲットアーキテクチャ
+
+```
+livecap-core/
+├── livecap_core/                  # 単一パッケージに統合
+│   ├── __init__.py                # 公開 API
+│   ├── cli.py                     # CLI エントリーポイント
+│   │
+│   ├── engines/                   # ASR エンジン（統合）
+│   │   ├── __init__.py
+│   │   ├── base.py                # シンプル化した基底クラス
+│   │   ├── factory.py
+│   │   ├── metadata.py
+│   │   └── impl/                  # 各エンジン実装
+│   │       ├── whisper.py
+│   │       ├── reazonspeech.py
+│   │       ├── parakeet.py
+│   │       ├── canary.py
+│   │       └── voxtral.py
+│   │
+│   ├── transcription/             # 文字起こしパイプライン
+│   │   ├── __init__.py
+│   │   ├── stream.py              # StreamTranscriber（新規・最重要）
+│   │   ├── file.py                # FileTranscriber（既存を簡素化）
+│   │   └── result.py              # 統一された結果型
+│   │
+│   ├── translation/               # 翻訳機能（新規）
+│   │   ├── __init__.py
+│   │   ├── base.py                # BaseTranslator
+│   │   ├── factory.py
+│   │   └── impl/
+│   │       ├── google.py          # deep-translator
+│   │       └── riva.py            # NVIDIA Riva
+│   │
+│   ├── vad/                       # VAD（新規モジュール化）
+│   │   ├── __init__.py
+│   │   ├── processor.py           # VADProcessor
+│   │   └── buffer.py              # AudioBuffer
+│   │
+│   ├── audio_sources/             # オーディオソース（オプショナル）
+│   │   ├── __init__.py
+│   │   ├── base.py                # AudioSource ABC
+│   │   ├── microphone.py          # sounddevice
+│   │   ├── system.py              # システム音声キャプチャ
+│   │   └── file.py                # ファイルストリーム
+│   │
+│   ├── config/                    # 設定（統合・簡素化）
+│   │   ├── __init__.py
+│   │   ├── schema.py              # 最小限のスキーマ
+│   │   └── defaults.py            # コア設定のみ
+│   │
+│   ├── resources/                 # リソース管理（維持）
+│   │   ├── model_manager.py
+│   │   ├── ffmpeg_manager.py
+│   │   └── resource_locator.py
+│   │
+│   ├── i18n.py                    # 国際化（維持）
+│   └── languages.py               # 言語定義（維持）
+│
+├── tests/
+├── docs/
+└── pyproject.toml
+```
+
+---
+
+## 3. 優先順位付きタスク
+
+### Phase 1: リアルタイム文字起こし実装（最優先）
+
+#### 1.1 StreamTranscriber の設計・実装
+
+**目的:** リアルタイム文字起こしの中核クラス
+
+```python
+class StreamTranscriber:
+    """リアルタイム文字起こしの中核"""
+
+    def __init__(
+        self,
+        engine: BaseEngine,
+        vad: Optional[VADProcessor] = None,
+        config: Optional[dict] = None,
+    ):
+        ...
+
+    def feed_audio(self, audio_chunk: np.ndarray, sample_rate: int = 16000) -> None:
+        """音声チャンクを入力（ノンブロッキング）"""
+        ...
+
+    def get_result(self) -> Optional[TranscriptionResult]:
+        """確定した結果を取得（ノンブロッキング）"""
+        ...
+
+    def get_interim(self) -> Optional[TranscriptionResult]:
+        """中間結果を取得"""
+        ...
+
+    async def transcribe_stream(
+        self,
+        audio_source: AsyncIterator[np.ndarray],
+    ) -> AsyncIterator[TranscriptionResult]:
+        """非同期ストリーム処理"""
+        ...
+
+    def reset(self) -> None:
+        """状態をリセット"""
+        ...
+
+    def close(self) -> None:
+        """リソース解放"""
+        ...
+```
+
+**設計ポイント:**
+- VAD 統合（オプショナル）
+- 中間結果と確定結果の区別
+- 非同期 API 対応
+- 低レイテンシ設計
+
+#### 1.2 VAD モジュールの分離
+
+**目的:** VAD 処理を独立モジュール化
+
+```python
+class VADProcessor:
+    """Voice Activity Detection プロセッサ"""
+
+    def __init__(self, config: VADConfig):
+        self._threshold = config.threshold
+        self._min_speech_ms = config.min_speech_ms
+        ...
+
+    def process(self, audio: np.ndarray, sample_rate: int) -> VADResult:
+        """音声を分析し、発話区間を検出"""
+        ...
+
+    def get_speech_segments(self) -> List[Tuple[float, float]]:
+        """検出された発話区間を取得"""
+        ...
+```
+
+#### 1.3 統一された結果型
+
+**目的:** API の二重構造を解消
+
+```python
+@dataclass
+class TranscriptionResult:
+    """統一された文字起こし結果"""
+    text: str
+    start_time: float
+    end_time: float
+    is_final: bool
+    confidence: float = 1.0
+    language: str = ""
+    source_id: str = "default"
+
+    def to_srt_entry(self, index: int) -> str:
+        """SRT 形式のエントリに変換"""
+        ...
+
+    def to_dict(self) -> dict:
+        """辞書形式に変換"""
+        ...
+```
+
+---
+
+### Phase 2: API 統一と Config 簡素化
+
+#### 2.1 Config の整理
+
+**削除すべきセクション:**
+- `multi_source`: GUI 専用
+- `silence_detection.vad_state_machine`: GUI 状態管理
+- `audio.processing`: GUI キュー管理
+- `queue`: GUI 専用
+
+**新しいコア設定:**
+
+```python
+CORE_CONFIG = {
+    "engine": {
+        "type": "auto",
+        "device": None,           # cuda/cpu/auto
+        "language": "ja",
+    },
+    "vad": {
+        "enabled": True,
+        "threshold": 0.5,
+        "min_speech_ms": 250,
+        "min_silence_ms": 100,
+    },
+    "translation": {
+        "enabled": False,
+        "service": "google",
+        "target_language": "en",
+    },
+}
+```
+
+#### 2.2 Config 統合
+
+- `config/core_config_builder.py` を `livecap_core/config/` に統合
+- GUI 変換ロジックは削除（GUI 側で対応）
+
+---
+
+### Phase 3: パッケージ構造整理
+
+#### 3.1 engines/ の統合
+
+```bash
+# 現在
+engines/
+├── base_engine.py
+├── engine_factory.py
+└── ...
+
+# 移行後
+livecap_core/engines/
+├── __init__.py
+├── base.py
+├── factory.py
+└── impl/
+    └── ...
+```
+
+#### 3.2 インポートパスの移行
+
+```python
+# 旧（廃止）
+from engines import EngineFactory
+
+# 新
+from livecap_core.engines import EngineFactory
+```
+
+**互換性:** 旧パスからのインポートは `DeprecationWarning` を出して新パスにリダイレクト。
+
+---
+
+### Phase 4: 翻訳機能実装
+
+#### 4.1 BaseTranslator と Factory
+
+```python
+class BaseTranslator(ABC):
+    @abstractmethod
+    def translate(self, text: str, source: str, target: str) -> str:
+        ...
+
+    @abstractmethod
+    async def translate_async(self, text: str, source: str, target: str) -> str:
+        ...
+
+    @abstractmethod
+    def get_supported_pairs(self) -> List[Tuple[str, str]]:
+        """サポートする言語ペアを取得"""
+        ...
+
+class TranslatorFactory:
+    @classmethod
+    def create(cls, service: str, config: dict) -> BaseTranslator:
+        ...
+```
+
+#### 4.2 実装
+
+- `GoogleTranslator`: deep-translator ベース
+- `RivaTranslator`: NVIDIA Riva NMT
+
+---
+
+### Phase 5: エンジン最適化
+
+#### 5.1 BaseEngine 簡素化
+
+**現在（6段階フェーズ）:**
+```python
+def load_model(self):
+    # Phase 1: CHECK_DEPENDENCIES
+    # Phase 2: PREPARE_DIRECTORY
+    # Phase 3: CHECK_FILES
+    # Phase 4: DOWNLOAD_MODEL
+    # Phase 5: LOAD_TO_MEMORY
+    # Phase 6: APPLY_SETTINGS
+```
+
+**簡素化後:**
+```python
+class BaseEngine(ABC):
+    def load_model(self, progress_callback: Optional[Callable] = None) -> None:
+        """モデルをロード。進捗報告はオプショナル"""
+        ...
+
+    @abstractmethod
+    def transcribe(self, audio: np.ndarray, sample_rate: int) -> TranscriptionResult:
+        ...
+
+    @abstractmethod
+    def get_required_sample_rate(self) -> int:
+        ...
+
+    def cleanup(self) -> None:
+        ...
+```
+
+#### 5.2 各エンジンの効率化
+
+- 不要なロギング削除
+- 推論パスの最適化
+- メモリ使用量の削減
+
+---
+
+### Phase 6: 依存関係整理
+
+#### 6.1 pyproject.toml 再構成
+
+```toml
+[project]
+dependencies = [
+    # 最小限のコア
+    "numpy",
+    "appdirs",
+    "tqdm",
+]
+
+[project.optional-dependencies]
+# VAD
+vad = ["ten-vad"]
+
+# エンジン（個別選択可能）
+engine-whisper = ["whisper-s2t"]
+engine-sherpa = ["sherpa-onnx"]
+engine-torch = ["torch", "torchaudio", "reazonspeech-k2-asr"]
+engine-nemo = ["nemo-toolkit[asr]"]
+
+# 翻訳
+translation-google = ["deep-translator"]
+translation-riva = ["nvidia-riva-client"]
+
+# オーディオキャプチャ（オプショナル）
+audio = ["sounddevice"]
+
+# 開発
+dev = ["pytest"]
+
+# 推奨セット
+recommended = [
+    "livecap-core[vad,engine-whisper,translation-google]"
+]
+
+# フルセット
+all = [
+    "livecap-core[vad,engine-whisper,engine-sherpa,engine-torch,engine-nemo,translation-google,translation-riva,audio]"
+]
+```
+
+---
+
+## 4. オーディオソースの設計方針
+
+### 4.1 コアの責務
+
+コアは **音声データ（`np.ndarray`）を受け取る** ことに専念。
+
+```python
+# コアの使用例
+transcriber = StreamTranscriber(engine=engine)
+
+# 呼び出し側がオーディオソースを管理
+while True:
+    audio_chunk = get_audio_from_somewhere()  # 外部
+    transcriber.feed_audio(audio_chunk)
+    if result := transcriber.get_result():
+        print(result.text)
+```
+
+### 4.2 オプショナルなオーディオソース
+
+`livecap_core.audio_sources` として提供（optional extra）:
+
+```python
+class AudioSource(ABC):
+    @abstractmethod
+    async def __aiter__(self) -> AsyncIterator[np.ndarray]:
+        ...
+
+    @abstractmethod
+    def close(self) -> None:
+        ...
+
+class MicrophoneSource(AudioSource):
+    """sounddevice ベースのマイク入力"""
+    def __init__(self, device_id: Optional[int] = None, sample_rate: int = 16000):
+        ...
+
+class SystemAudioSource(AudioSource):
+    """システム音声キャプチャ"""
+    # Windows: PyWAC
+    # Linux: PulseAudio
+    ...
+
+class FileSource(AudioSource):
+    """ファイルからのストリーム（テスト用にも有用）"""
+    def __init__(self, file_path: Path, chunk_duration_ms: int = 100):
+        ...
+```
+
+**理由:**
+- テスト容易性（`FileSource` でハードウェアなしテスト可能）
+- クロスプラットフォーム対応を分離
+- 依存関係を軽量に保てる
+
+---
+
+## 5. マイルストーン
+
+| マイルストーン | 内容 | 依存 |
+|---------------|------|------|
+| M1 | StreamTranscriber + VAD モジュール | - |
+| M2 | 統一結果型 + API 整理 | M1 |
+| M3 | Config 簡素化 | M2 |
+| M4 | パッケージ構造統合 | M3 |
+| M5 | 翻訳機能実装 | M4 |
+| M6 | エンジン最適化 | M4 |
+| M7 | 依存関係整理 | M5, M6 |
+| M8 | ドキュメント整備 | M7 |
+
+---
+
+## 6. 移行戦略
+
+### 6.1 破壊的変更の管理
+
+**現状:** 本リポジトリは外部で利用されておらず、動作可能な状態ではない。
+
+**方針:** 互換性維持は不要。破壊的変更を積極的に行い、クリーンな API 設計を優先する。
+
+- 旧 API の非推奨期間は設けない
+- 不要なコードは即座に削除
+- インポートパスの変更も躊躇なく実施
+
+### 6.2 テスト戦略
+
+- 既存テストは必要に応じて更新・削除
+- 新機能には必ずユニットテスト追加
+- リアルタイム処理のベンチマーク追加
+
+---
+
+## 7. 決定事項・未決定事項
+
+### 7.1 決定済み
+
+1. **パッケージ名変更**
+   - `livecap-core` → `livecap-cli` にリネーム予定
+   - **優先度:** 低（リファクタリング完了後に対応）
+
+2. **GPU/CPU デバイス選択**
+   - `auto` / `gpu` / `cpu` の3オプションを提供
+   - `auto`: CUDA 利用可能なら GPU、なければ CPU
+   - 設定例: `--device auto`
+
+### 7.2 検討中
+
+1. **CLI の機能範囲（オーディオソース取得）**
+   - CLI でマイク/システム音声からの直接リアルタイム文字起こしを提供するか？
+   - **選択肢:**
+     - A) 含める: `livecap-cli transcribe --realtime --device 0`
+     - B) 含めない: CLI はファイル処理のみ、リアルタイムはライブラリ API として提供
+   - **影響:** `audio_sources/` モジュールの位置づけが変わる
+
+---
+
+## 8. 関連ドキュメント
+
+- [feature-inventory.md](../reference/feature-inventory.md) - 現在の機能一覧
+- [core-api-spec.md](../architecture/core-api-spec.md) - 現在の API 仕様
+
+---
+
+## 変更履歴
+
+| 日付 | 変更内容 |
+|------|----------|
+| 2025-11-25 | 初版作成 |
+| 2025-11-25 | 7章: パッケージ名・デバイス選択を決定済みに移動 |
+| 2025-11-25 | 6章: 互換性維持不要の方針を追記 |

--- a/docs/reference/feature-inventory.md
+++ b/docs/reference/feature-inventory.md
@@ -1,0 +1,871 @@
+# LiveCap Core 機能一覧
+
+> **作成日:** 2025-11-25
+> **目的:** 現在実装されている全機能の棚卸しとサンプルコード
+
+---
+
+## 1. パッケージ構成
+
+```
+livecap-core/
+├── livecap_core/           # コアライブラリ
+│   ├── __init__.py         # 公開APIエクスポート
+│   ├── cli.py              # CLI・診断機能
+│   ├── i18n.py             # 国際化ヘルパー
+│   ├── languages.py        # 言語定義
+│   ├── transcription_types.py  # イベント型定義
+│   ├── config/
+│   │   ├── defaults.py     # デフォルト設定
+│   │   ├── schema.py       # TypedDictスキーマ
+│   │   └── validator.py    # 設定バリデーション
+│   ├── resources/
+│   │   ├── model_manager.py    # モデルキャッシュ管理
+│   │   ├── ffmpeg_manager.py   # FFmpegバイナリ管理
+│   │   └── resource_locator.py # リソースパス解決
+│   ├── transcription/
+│   │   └── file_pipeline.py    # ファイル文字起こしパイプライン
+│   └── utils/
+│       └── __init__.py
+├── engines/                # ASRエンジン実装
+│   ├── base_engine.py      # 抽象基底クラス
+│   ├── engine_factory.py   # エンジンファクトリ
+│   ├── metadata.py         # エンジンメタデータ
+│   ├── reazonspeech_engine.py
+│   ├── whispers2t_engine.py
+│   ├── parakeet_engine.py
+│   ├── canary_engine.py
+│   └── voxtral_engine.py
+└── config/                 # 設定ビルダー
+    └── core_config_builder.py
+```
+
+---
+
+## 2. 機能別詳細
+
+### 2.1 言語サポート (`livecap_core.languages`)
+
+**概要:** 16言語のメタデータ管理、言語コード正規化、エンジンマッピング
+
+**対応言語:**
+- ja (日本語), en (English), zh-CN (簡体中文), zh-TW (繁體中文)
+- ko (한국어), de (Deutsch), fr (Français), es (Español)
+- ru (Русский), ar (العربية), pt (Português), it (Italiano)
+- hi (हिन्दी), nl (Nederlands)
+- 地域バリアント: es-ES, es-US, pt-BR
+
+**サンプルコード:**
+
+```python
+from livecap_core.languages import Languages, LanguageInfo
+
+# === 言語コードの正規化 ===
+print(Languages.normalize("JA"))       # "ja"
+print(Languages.normalize("zh-TW"))    # "zh-TW"（繁体字は保持）
+print(Languages.normalize("zh"))       # "zh-CN"（デフォルトは簡体字）
+print(Languages.normalize("en-us"))    # "en"
+print(Languages.normalize("auto"))     # "auto"（特殊コード）
+
+# === 言語情報の取得 ===
+info: LanguageInfo = Languages.get_info("ja")
+print(f"表示名: {info.display_name}")        # "日本語"
+print(f"英語名: {info.english_name}")        # "Japanese"
+print(f"国旗: {info.flag}")                  # "🇯🇵"
+print(f"ISO 639-1: {info.iso639_1}")         # "ja"
+print(f"Windows LCID: {hex(info.windows_lcid)}")  # "0x411"
+
+# === 表示名の取得 ===
+print(Languages.get_display_name("ja"))              # "日本語"
+print(Languages.get_display_name("ja", english=True)) # "Japanese"
+
+# === エンジンマッピング ===
+engines = Languages.get_engines_for_language("ja")
+print(engines)  # ["reazonspeech", "whispers2t_base", "whispers2t_tiny", ...]
+
+# === バリデーション ===
+print(Languages.is_valid("ja"))      # True
+print(Languages.is_valid("invalid")) # False
+
+# === 自動検出モードの判定 ===
+print(Languages.is_auto("auto"))     # True
+print(Languages.is_auto("ja"))       # False
+
+# === サポート言語一覧 ===
+codes = Languages.get_supported_codes()
+print(codes)  # {"ja", "en", "zh-CN", "zh-TW", ...}
+
+# === 翻訳サービス対応言語 ===
+google_langs = Languages.get_languages_for_translation_service("google")
+print(google_langs)  # [("ja", "日本語"), ("en", "English"), ...]
+
+# === Windows LCID から言語コード ===
+lang = Languages.from_windows_lcid(0x0411)
+print(lang)  # "ja"
+```
+
+---
+
+### 2.2 ファイル文字起こしパイプライン (`livecap_core.transcription`)
+
+**概要:** 音声/動画ファイルの文字起こしとSRT字幕生成
+
+**対応フォーマット:** .wav, .flac, .mp3, .m4a, .aac, .ogg, .wma, .opus + FFmpegで変換可能な動画
+
+**サンプルコード:**
+
+```python
+from pathlib import Path
+from livecap_core import (
+    FileTranscriptionPipeline,
+    FileTranscriptionProgress,
+    FileProcessingResult,
+    FileSubtitleSegment,
+    FileTranscriptionCancelled,
+)
+from livecap_core.config import get_default_config
+import numpy as np
+
+# === 基本的な使用方法 ===
+def simple_transcriber(audio_data: np.ndarray, sample_rate: int) -> str:
+    """音声データを受け取り、文字起こし結果を返すコールバック"""
+    # 実際にはASRエンジンを呼び出す
+    return "文字起こし結果"
+
+config = get_default_config()
+pipeline = FileTranscriptionPipeline(config=config)
+
+try:
+    result = pipeline.process_file(
+        file_path=Path("audio.wav"),
+        segment_transcriber=simple_transcriber,
+    )
+
+    print(f"成功: {result.success}")
+    print(f"出力パス: {result.output_path}")  # audio.srt
+
+    for segment in result.subtitles:
+        print(f"{segment.start:.2f}-{segment.end:.2f}: {segment.text}")
+finally:
+    pipeline.close()
+
+# === 進捗コールバック付き ===
+def on_progress(progress: FileTranscriptionProgress):
+    print(f"[{progress.current}/{progress.total}] {progress.status}")
+    if progress.context:
+        print(f"  詳細: {progress.context}")
+
+result = pipeline.process_file(
+    file_path=Path("audio.wav"),
+    segment_transcriber=simple_transcriber,
+    progress_callback=on_progress,
+)
+
+# === 複数ファイル処理 ===
+def on_status(message: str):
+    print(f"ステータス: {message}")
+
+def on_result(result: FileProcessingResult):
+    print(f"完了: {result.source_path} - {'成功' if result.success else '失敗'}")
+
+def on_error(message: str, exception: Exception):
+    print(f"エラー: {message}")
+
+# キャンセル制御
+cancel_flag = False
+def should_cancel() -> bool:
+    return cancel_flag
+
+results = pipeline.process_files(
+    file_paths=[Path("audio1.wav"), Path("audio2.mp3"), Path("video.mp4")],
+    segment_transcriber=simple_transcriber,
+    progress_callback=on_progress,
+    status_callback=on_status,
+    result_callback=on_result,
+    error_callback=on_error,
+    should_cancel=should_cancel,
+    write_subtitles=True,
+)
+
+# === カスタムセグメンター ===
+from typing import List, Tuple
+
+def custom_segmenter(audio: np.ndarray, sample_rate: int) -> List[Tuple[float, float]]:
+    """音声をセグメントに分割するカスタム関数"""
+    duration = len(audio) / sample_rate
+    # 5秒ごとにセグメント化
+    segments = []
+    for start in range(0, int(duration), 5):
+        end = min(start + 5, duration)
+        segments.append((float(start), float(end)))
+    return segments
+
+pipeline_with_segmenter = FileTranscriptionPipeline(
+    config=config,
+    segmenter=custom_segmenter,
+)
+
+# === キャンセル処理 ===
+try:
+    result = pipeline.process_file(
+        file_path=Path("long_audio.wav"),
+        segment_transcriber=simple_transcriber,
+        should_cancel=lambda: True,  # 即座にキャンセル
+    )
+except FileTranscriptionCancelled:
+    print("処理がキャンセルされました")
+```
+
+---
+
+### 2.3 ASRエンジン (`engines`)
+
+**概要:** 複数のASRエンジンを統一インターフェースで提供
+
+**利用可能なエンジン:**
+
+| エンジンID | モデル名 | サイズ | 対応言語 |
+|-----------|---------|--------|---------|
+| `reazonspeech` | ReazonSpeech K2 v2 | 159MB | ja |
+| `parakeet` | Parakeet TDT 0.6B v2 | 1.2GB | en |
+| `parakeet_ja` | Parakeet TDT CTC 0.6B JA | 600MB | ja |
+| `canary` | Canary 1B Flash | 1.5GB | en, de, fr, es |
+| `voxtral` | Voxtral Mini 3B | 3GB | en, es, fr, pt, hi, de, nl, it |
+| `whispers2t_tiny` | Whisper Tiny | 39MB | 13言語 |
+| `whispers2t_base` | Whisper Base | 74MB | 13言語 |
+| `whispers2t_small` | Whisper Small | 244MB | 13言語 |
+| `whispers2t_medium` | Whisper Medium | 769MB | 13言語 |
+| `whispers2t_large_v3` | Whisper Large-v3 | 1.55GB | 13言語 |
+
+**サンプルコード:**
+
+```python
+from engines import EngineFactory, BaseEngine
+from engines.metadata import EngineMetadata, EngineInfo
+from livecap_core.config import get_default_config
+import numpy as np
+
+# === エンジンの作成と使用 ===
+config = get_default_config()
+
+# エンジンを作成
+engine = EngineFactory.create_engine(
+    engine_type="whispers2t_base",
+    device="cuda",  # または "cpu"
+    config=config,
+)
+
+# 進捗コールバックの設定
+def on_model_progress(percent: int, message: str):
+    print(f"[{percent}%] {message}")
+
+engine.set_progress_callback(on_model_progress)
+
+# モデルのロード
+engine.load_model()
+
+# 音声データの文字起こし
+audio_data = np.zeros(16000, dtype=np.float32)  # 1秒の無音
+sample_rate = 16000
+
+text, confidence = engine.transcribe(audio_data, sample_rate)
+print(f"結果: {text} (確信度: {confidence:.2f})")
+
+# クリーンアップ
+engine.cleanup()
+
+# === 自動エンジン選択 ===
+config["transcription"]["engine"] = "auto"
+config["transcription"]["input_language"] = "ja"
+
+engine = EngineFactory.create_engine(
+    engine_type="auto",
+    device="cuda",
+    config=config,
+)
+# 日本語の場合、reazonspeechが自動選択される
+
+# === 利用可能なエンジン情報 ===
+available = EngineFactory.get_available_engines()
+for engine_id, info in available.items():
+    print(f"{engine_id}: {info['name']} - {info['description']}")
+
+# 特定エンジンの情報
+info = EngineFactory.get_engine_info("whispers2t_base")
+print(f"名前: {info['name']}")
+print(f"説明: {info['description']}")
+print(f"対応言語: {info['supported_languages']}")
+
+# 言語別エンジン一覧
+ja_engines = EngineFactory.get_engines_for_language("ja")
+print(f"日本語対応: {list(ja_engines.keys())}")
+
+# デフォルトエンジンの取得
+default_en = EngineFactory.get_default_engine_for_language("en", config)
+print(f"英語のデフォルト: {default_en}")
+
+# === エンジンメタデータの直接アクセス ===
+metadata: EngineInfo = EngineMetadata.get("reazonspeech")
+print(f"ID: {metadata.id}")
+print(f"表示名: {metadata.display_name}")
+print(f"サイズ: {metadata.model_size}")
+print(f"デバイス: {metadata.device_support}")
+print(f"ストリーミング: {metadata.streaming}")
+
+# 全エンジン取得
+all_engines = EngineMetadata.get_all()
+for eid, einfo in all_engines.items():
+    print(f"{eid}: {einfo.display_name}")
+
+# 言語別エンジンリスト
+ja_engines = EngineMetadata.get_engines_for_language("ja")
+print(f"日本語対応: {ja_engines}")
+```
+
+---
+
+### 2.4 設定管理 (`livecap_core.config`)
+
+**概要:** デフォルト設定、マージ、バリデーション
+
+**サンプルコード:**
+
+```python
+from livecap_core.config import (
+    DEFAULT_CONFIG,
+    get_default_config,
+    merge_config,
+    ConfigValidator,
+    ValidationError,
+)
+from config import build_core_config
+
+# === デフォルト設定の取得 ===
+config = get_default_config()  # ディープコピーを返す
+
+# 設定のセクション
+print(config["audio"]["sample_rate"])           # 16000
+print(config["transcription"]["engine"])         # "auto"
+print(config["transcription"]["input_language"]) # "ja"
+print(config["translation"]["enabled"])          # False
+
+# === 設定のマージ ===
+user_config = {
+    "transcription": {
+        "engine": "whispers2t_base",
+        "input_language": "en",
+    },
+    "translation": {
+        "enabled": True,
+        "target_language": "ja",
+    },
+}
+
+merged = merge_config(get_default_config(), user_config)
+print(merged["transcription"]["engine"])  # "whispers2t_base"
+print(merged["audio"]["sample_rate"])     # 16000（デフォルト値を継承）
+
+# === GUI設定からCore設定への変換 ===
+gui_config = {
+    "transcription": {
+        "engine": "reazonspeech",
+    },
+    "translation": {
+        "enable_translation": True,  # GUI形式のキー
+        "translation_service": "google",
+    },
+}
+
+core_config = build_core_config(gui_config)
+# キーが正規化される: enable_translation → enabled
+print(core_config["translation"]["enabled"])  # True
+print(core_config["translation"]["service"])  # "google"
+
+# === 設定バリデーション ===
+errors = ConfigValidator.validate(config)
+if errors:
+    for err in errors:
+        print(f"{err.path}: {err.message}")
+else:
+    print("設定は有効です")
+
+# 例外を投げるバリデーション
+try:
+    ConfigValidator.validate_or_raise(config)
+except ValueError as e:
+    print(f"バリデーションエラー: {e}")
+
+# === デフォルト設定の構造 ===
+"""
+DEFAULT_CONFIG = {
+    "audio": {
+        "sample_rate": 16000,
+        "chunk_duration": 0.25,
+        "input_device": None,
+        "processing": {...}
+    },
+    "multi_source": {
+        "max_sources": 3,
+        "defaults": {...},
+        "sources": {}
+    },
+    "silence_detection": {
+        "vad_threshold": 0.5,
+        "vad_min_speech_duration_ms": 250,
+        ...
+    },
+    "transcription": {
+        "device": None,
+        "engine": "auto",
+        "input_language": "ja",
+        "language_engines": {...},
+        "reazonspeech_config": {...}
+    },
+    "translation": {
+        "enabled": False,
+        "service": "google",
+        "target_language": "en",
+        ...
+    },
+    "engines": {...},
+    "logging": {...},
+    "queue": {...},
+    "debug": {...},
+    "file_mode": {...}
+}
+"""
+```
+
+---
+
+### 2.5 リソース管理 (`livecap_core.resources`)
+
+**概要:** モデルキャッシュ、FFmpegバイナリ、リソースパスの管理
+
+**サンプルコード:**
+
+```python
+from livecap_core.resources import (
+    ModelManager,
+    FFmpegManager,
+    FFmpegNotFoundError,
+    ResourceLocator,
+    get_model_manager,
+    get_ffmpeg_manager,
+    get_resource_locator,
+    reset_resource_managers,
+)
+
+# === ModelManager: モデルキャッシュ管理 ===
+model_manager = get_model_manager()
+
+# ディレクトリパス
+print(f"モデルルート: {model_manager.models_root}")
+print(f"キャッシュルート: {model_manager.cache_root}")
+
+# エンジン固有のモデルディレクトリ
+whisper_dir = model_manager.get_models_dir("whispers2t")
+print(f"Whisperモデル: {whisper_dir}")
+
+# 一時ディレクトリ
+temp_dir = model_manager.get_temp_dir("processing")
+print(f"一時ディレクトリ: {temp_dir}")
+
+# ファイルダウンロード
+def on_progress(downloaded: int, total: int):
+    percent = (downloaded / total * 100) if total > 0 else 0
+    print(f"ダウンロード中: {percent:.1f}%")
+
+downloaded_path = model_manager.download_file(
+    url="https://example.com/model.bin",
+    filename="model.bin",
+    expected_sha256="abc123...",  # オプション
+    progress_callback=on_progress,
+)
+
+# 非同期ダウンロード
+import asyncio
+
+async def download_async():
+    path = await model_manager.download_file_async(
+        url="https://example.com/model.bin",
+        filename="model.bin",
+    )
+    return path
+
+# 一時ディレクトリのコンテキストマネージャ
+with model_manager.temporary_directory("extraction") as temp:
+    # tempは自動的にクリーンアップされる
+    print(f"一時作業ディレクトリ: {temp}")
+
+# HuggingFaceキャッシュ管理
+with model_manager.huggingface_cache() as cache_dir:
+    # HF_HOMEが自動設定される
+    print(f"HFキャッシュ: {cache_dir}")
+
+# === FFmpegManager: FFmpegバイナリ管理 ===
+ffmpeg_manager = get_ffmpeg_manager()
+
+# FFmpegの検索
+try:
+    ffmpeg_path = ffmpeg_manager.resolve_executable()
+    print(f"FFmpeg: {ffmpeg_path}")
+except FFmpegNotFoundError:
+    print("FFmpegが見つかりません")
+
+# FFprobeの検索
+ffprobe_path = ffmpeg_manager.resolve_probe()
+print(f"FFprobe: {ffprobe_path}")
+
+# FFmpegの確保（必要ならダウンロード）
+ffmpeg_path = ffmpeg_manager.ensure_executable()
+print(f"FFmpeg確保: {ffmpeg_path}")
+
+# 非同期版
+async def ensure_async():
+    path = await ffmpeg_manager.ensure_executable_async()
+    return path
+
+# 環境設定（PATHに追加）
+ffmpeg_path = ffmpeg_manager.configure_environment()
+print(f"環境設定完了: {ffmpeg_path}")
+
+# === ResourceLocator: リソースパス解決 ===
+locator = get_resource_locator()
+
+try:
+    bin_path = locator.resolve("ffmpeg-bin")
+    print(f"FFmpegバイナリ: {bin_path}")
+except FileNotFoundError:
+    print("リソースが見つかりません")
+
+# === シングルトンのリセット（テスト用） ===
+reset_resource_managers()
+```
+
+---
+
+### 2.6 イベントシステム (`livecap_core.transcription_types`)
+
+**概要:** 文字起こし結果、ステータス、エラー等のイベント型定義
+
+**イベント型:**
+- `TranscriptionEventDict`: 文字起こし結果
+- `StatusEventDict`: ステータス変更
+- `ErrorEventDict`: エラー通知
+- `TranslationRequestEventDict`: 翻訳リクエスト
+- `TranslationResultEventDict`: 翻訳結果
+- `SubtitleEventDict`: 字幕送信
+
+**サンプルコード:**
+
+```python
+from livecap_core import (
+    create_transcription_event,
+    create_status_event,
+    create_error_event,
+    create_translation_request_event,
+    create_translation_result_event,
+    create_subtitle_event,
+    validate_event_dict,
+    get_event_type_name,
+    normalize_to_event_dict,
+    format_event_summary,
+)
+
+# === イベント作成 ===
+
+# 文字起こしイベント
+transcription = create_transcription_event(
+    text="こんにちは",
+    source_id="source1",
+    is_final=True,
+    confidence=0.95,
+    language="ja",
+)
+print(transcription)
+# {'event_type': 'transcription', 'text': 'こんにちは', 'source_id': 'source1',
+#  'is_final': True, 'timestamp': 1732..., 'confidence': 0.95, 'language': 'ja', 'phase': 'final'}
+
+# ステータスイベント
+status = create_status_event(
+    status_code="ready",
+    message="エンジン準備完了",
+    source_id="source1",
+    phase="ready",
+)
+print(status)
+
+# エラーイベント
+error = create_error_event(
+    error_code="MODEL_LOAD_FAILED",
+    message="モデルの読み込みに失敗しました",
+    source_id="source1",
+    error_details="詳細なエラー情報...",
+)
+print(error)
+
+# 翻訳リクエスト
+translation_req = create_translation_request_event(
+    text="こんにちは",
+    source_id="source1",
+    source_language="ja",
+    target_language="en",
+)
+print(translation_req)
+
+# 翻訳結果
+translation_result = create_translation_result_event(
+    original_text="こんにちは",
+    translated_text="Hello",
+    source_id="source1",
+    source_language="ja",
+    target_language="en",
+    confidence=0.98,
+)
+print(translation_result)
+
+# 字幕イベント
+subtitle = create_subtitle_event(
+    text="こんにちは",
+    source_id="source1",
+    destination="obs",  # "obs" or "vrchat"
+    is_translated=False,
+)
+print(subtitle)
+
+# === バリデーション ===
+is_valid = validate_event_dict(transcription)
+print(f"有効: {is_valid}")  # True
+
+# === ユーティリティ ===
+event_type = get_event_type_name(transcription)
+print(f"イベントタイプ: {event_type}")  # "transcription"
+
+summary = format_event_summary(transcription)
+print(f"サマリー: {summary}")  # "[source1] Final: こんにちは..."
+
+# 古い形式の正規化
+old_format = {"text": "テスト", "source_id": "src1"}
+normalized = normalize_to_event_dict(old_format)
+print(normalized)  # event_type等が追加される
+```
+
+---
+
+### 2.7 CLI・診断 (`livecap_core.cli`)
+
+**概要:** コマンドラインからの診断と設定ダンプ
+
+**コマンドライン使用法:**
+
+```bash
+# 基本診断
+python -m livecap_core
+
+# JSON形式で出力
+python -m livecap_core --as-json
+
+# デフォルト設定を出力
+python -m livecap_core --dump-config
+
+# FFmpegを確保（ダウンロード）
+python -m livecap_core --ensure-ffmpeg
+```
+
+**プログラム的使用:**
+
+```python
+from livecap_core.cli import diagnose, DiagnosticReport, main
+from livecap_core.config import get_default_config
+
+# 診断の実行
+report: DiagnosticReport = diagnose(
+    ensure_ffmpeg=False,
+    config=get_default_config(),
+)
+
+print(f"設定有効: {report.config_valid}")
+print(f"設定エラー: {report.config_errors}")
+print(f"モデルルート: {report.models_root}")
+print(f"キャッシュルート: {report.cache_root}")
+print(f"FFmpegパス: {report.ffmpeg_path}")
+print(f"i18nフォールバック数: {report.i18n.fallback_count}")
+
+# JSON出力
+json_output = report.to_json()
+print(json_output)
+
+# プログラムからCLIを実行
+exit_code = main(["--dump-config"])
+```
+
+---
+
+### 2.8 国際化 (`livecap_core.i18n`)
+
+**概要:** 翻訳関数の登録とフォールバックメッセージ管理
+
+**サンプルコード:**
+
+```python
+from livecap_core.i18n import (
+    translate,
+    register_translator,
+    register_fallbacks,
+    diagnose,
+    I18nManager,
+)
+
+# === フォールバックの登録 ===
+register_fallbacks({
+    "status.loading": "読み込み中...",
+    "status.ready": "準備完了",
+    "error.model_not_found": "モデルが見つかりません: {model_name}",
+})
+
+# フォールバックを使った翻訳
+message = translate("status.loading")
+print(message)  # "読み込み中..."
+
+# プレースホルダー付き
+message = translate("error.model_not_found", model_name="whispers2t")
+print(message)  # "モデルが見つかりません: whispers2t"
+
+# 未登録キーはキー自体を返す
+message = translate("unknown.key")
+print(message)  # "unknown.key"
+
+# デフォルト値の指定
+message = translate("unknown.key", default="デフォルトメッセージ")
+print(message)  # "デフォルトメッセージ"
+
+# === カスタム翻訳関数の登録 ===
+def my_translator(key: str, **kwargs) -> str:
+    translations = {
+        "status.loading": "Loading...",
+        "status.ready": "Ready",
+    }
+    return translations.get(key, key)
+
+register_translator(
+    my_translator,
+    name="MyTranslator",
+    extras=["en", "ja"],
+    metadata={"version": "1.0"},
+)
+
+# 登録後はカスタム翻訳関数が優先される
+message = translate("status.ready")
+print(message)  # "Ready"
+
+# === 診断情報 ===
+diagnostics = diagnose()
+print(f"翻訳関数登録済み: {diagnostics.translator.registered}")
+print(f"翻訳関数名: {diagnostics.translator.name}")
+print(f"フォールバック数: {diagnostics.fallback_count}")
+```
+
+---
+
+## 3. 環境変数
+
+| 変数名 | 説明 | デフォルト |
+|--------|------|-----------|
+| `LIVECAP_CORE_MODELS_DIR` | モデル保存ディレクトリ | `~/.cache/LiveCap/PineLab/models` |
+| `LIVECAP_CORE_CACHE_DIR` | キャッシュディレクトリ | `~/.cache/LiveCap/PineLab/cache` |
+| `LIVECAP_FFMPEG_BIN` | FFmpegバイナリディレクトリ | 自動検出 |
+
+---
+
+## 4. 依存関係とインストール
+
+```bash
+# 基本インストール
+pip install livecap-core
+
+# 翻訳サポート付き
+pip install livecap-core[translation]
+
+# 開発ツール付き
+pip install livecap-core[dev]
+
+# PyTorchエンジン付き（ReazonSpeech, Whisper）
+pip install livecap-core[engines-torch]
+
+# NeMoエンジン付き（Parakeet, Canary）
+pip install livecap-core[engines-nemo]
+```
+
+---
+
+## 5. 統合使用例
+
+### 5.1 ファイル文字起こし完全例
+
+```python
+from pathlib import Path
+from livecap_core import FileTranscriptionPipeline, FileTranscriptionProgress
+from livecap_core.config import get_default_config, merge_config
+from engines import EngineFactory
+
+# 設定の準備
+user_config = {
+    "transcription": {
+        "engine": "whispers2t_base",
+        "input_language": "ja",
+    },
+}
+config = merge_config(get_default_config(), user_config)
+
+# エンジンの初期化
+engine = EngineFactory.create_engine(
+    engine_type=config["transcription"]["engine"],
+    device="cuda",
+    config=config,
+)
+
+def on_model_progress(percent: int, message: str):
+    print(f"モデル読込: [{percent}%] {message}")
+
+engine.set_progress_callback(on_model_progress)
+engine.load_model()
+
+# 文字起こし関数の定義
+def transcriber(audio_data, sample_rate):
+    text, confidence = engine.transcribe(audio_data, sample_rate)
+    return text
+
+# パイプラインの実行
+def on_progress(progress: FileTranscriptionProgress):
+    print(f"処理中: [{progress.current}/{progress.total}] {progress.status}")
+
+pipeline = FileTranscriptionPipeline(config=config)
+
+try:
+    result = pipeline.process_file(
+        file_path=Path("interview.mp4"),
+        segment_transcriber=transcriber,
+        progress_callback=on_progress,
+    )
+
+    if result.success:
+        print(f"字幕ファイル: {result.output_path}")
+        print(f"セグメント数: {len(result.subtitles)}")
+        print(f"音声長: {result.metadata['duration_seconds']:.2f}秒")
+    else:
+        print(f"エラー: {result.error}")
+finally:
+    pipeline.close()
+    engine.cleanup()
+```
+
+---
+
+## 6. 未実装・将来の機能
+
+以下の機能は仕様書に記載があるが、現時点で実装状況の確認が必要:
+
+1. **リアルタイム文字起こし** - `FileTranscriptionPipeline`はファイルベースのみ
+2. **翻訳パイプライン統合** - `translation`設定は存在するが、パイプラインとの統合詳細未確認
+3. **PyPI公開** - `pip install livecap-core`は記載されているが未公開


### PR DESCRIPTION
## Summary
- リファクタリング計画とドキュメント構成の整理

## 追加ファイル

### docs/planning/refactoring-plan.md
包括的なリファクタリング計画：
- **目的:** 高速なリアルタイム文字起こしの提供
- **Phase 1:** StreamTranscriber + VAD 実装（最優先）
- **Phase 2:** API 統一・Config 簡素化
- **Phase 3:** パッケージ構造統合
- **Phase 4:** 翻訳機能実装
- **Phase 5-6:** エンジン最適化・依存関係整理

**決定事項:**
- パッケージ名: `livecap-core` → `livecap-cli`（優先度低）
- デバイス選択: `auto` / `gpu` / `cpu`
- 互換性維持: 不要（破壊的変更を積極的に実施）

### docs/reference/feature-inventory.md
現在実装されている全機能の棚卸しとサンプルコード

## ドキュメント構成
```
docs/
├── architecture/
│   └── core-api-spec.md
├── planning/          # 新規
│   └── refactoring-plan.md
├── reference/         # 新規
│   └── feature-inventory.md
└── testing/
    └── README.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)