### PR TITLE
feat(transcription): add TranscriptionResult and InterimResult types [Phase1 Step1]

### DIFF
--- a/livecap_core/transcription/__init__.py
+++ b/livecap_core/transcription/__init__.py
@@ -13,8 +13,10 @@ from .file_pipeline import (
     SegmentTranscriber,
     Segmenter,
 )
+from .result import TranscriptionResult, InterimResult
 
 __all__ = [
+    # File transcription (existing)
     "FileTranscriptionPipeline",
     "FileTranscriptionProgress",
     "FileProcessingResult",
@@ -26,4 +28,7 @@ __all__ = [
     "ErrorCallback",
     "SegmentTranscriber",
     "Segmenter",
+    # Realtime transcription result types (Phase 1)
+    "TranscriptionResult",
+    "InterimResult",
 ]

--- a/livecap_core/transcription/result.py
+++ b/livecap_core/transcription/result.py
@@ -1,0 +1,95 @@
+"""統一された文字起こし結果型
+
+リアルタイム・ファイル文字起こし両方で使用する統一型を定義。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptionResult:
+    """
+    文字起こし結果を表すイミュータブルなデータクラス
+
+    リアルタイム・ファイル文字起こし両方で使用する統一型。
+
+    Attributes:
+        text: 文字起こしテキスト
+        start_time: セグメント開始時刻（秒）
+        end_time: セグメント終了時刻（秒）
+        is_final: 確定結果かどうか（リアルタイム用）
+        confidence: 信頼度スコア（0.0-1.0）
+        language: 検出された言語コード
+        source_id: 音声ソースID（マルチソース対応用）
+    """
+
+    text: str
+    start_time: float
+    end_time: float
+    is_final: bool = True
+    confidence: float = 1.0
+    language: str = ""
+    source_id: str = "default"
+
+    @property
+    def duration(self) -> float:
+        """セグメントの長さ（秒）"""
+        return self.end_time - self.start_time
+
+    def to_srt_entry(self, index: int) -> str:
+        """
+        SRT形式のエントリに変換
+
+        Args:
+            index: SRTエントリの番号（1から開始）
+
+        Returns:
+            SRT形式の文字列
+        """
+        return (
+            f"{index}\n"
+            f"{_format_srt_time(self.start_time)} --> {_format_srt_time(self.end_time)}\n"
+            f"{self.text}\n"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class InterimResult:
+    """
+    中間結果（確定前の途中経過）
+
+    TranscriptionResult とは別の型として明示的に区別。
+    リアルタイム文字起こしで、発話中の途中経過を表示するために使用。
+
+    Attributes:
+        text: 中間テキスト
+        accumulated_time: 発話開始からの累積時間（秒）
+        source_id: 音声ソースID
+    """
+
+    text: str
+    accumulated_time: float
+    source_id: str = "default"
+
+
+def _format_srt_time(seconds: float) -> str:
+    """
+    秒数をSRT形式のタイムスタンプに変換
+
+    Args:
+        seconds: 秒数
+
+    Returns:
+        "HH:MM:SS,mmm" 形式の文字列
+    """
+    if seconds < 0:
+        seconds = 0.0
+
+    hours = int(seconds // 3600)
+    minutes = int((seconds % 3600) // 60)
+    secs = int(seconds % 60)
+    millis = int((seconds % 1) * 1000)
+
+    return f"{hours:02d}:{minutes:02d}:{secs:02d},{millis:03d}"

--- a/tests/transcription/test_result.py
+++ b/tests/transcription/test_result.py
@@ -1,0 +1,201 @@
+"""TranscriptionResult / InterimResult のユニットテスト"""
+
+import pytest
+from dataclasses import FrozenInstanceError
+
+from livecap_core.transcription.result import (
+    TranscriptionResult,
+    InterimResult,
+    _format_srt_time,
+)
+
+
+class TestTranscriptionResult:
+    """TranscriptionResult のテスト"""
+
+    def test_create_basic(self):
+        """基本的な生成テスト"""
+        result = TranscriptionResult(
+            text="こんにちは",
+            start_time=0.0,
+            end_time=1.5,
+        )
+
+        assert result.text == "こんにちは"
+        assert result.start_time == 0.0
+        assert result.end_time == 1.5
+        assert result.is_final is True
+        assert result.confidence == 1.0
+        assert result.language == ""
+        assert result.source_id == "default"
+
+    def test_create_with_all_fields(self):
+        """全フィールド指定のテスト"""
+        result = TranscriptionResult(
+            text="Hello",
+            start_time=10.5,
+            end_time=12.0,
+            is_final=False,
+            confidence=0.95,
+            language="en",
+            source_id="mic1",
+        )
+
+        assert result.text == "Hello"
+        assert result.start_time == 10.5
+        assert result.end_time == 12.0
+        assert result.is_final is False
+        assert result.confidence == 0.95
+        assert result.language == "en"
+        assert result.source_id == "mic1"
+
+    def test_duration_property(self):
+        """duration プロパティのテスト"""
+        result = TranscriptionResult(
+            text="test",
+            start_time=5.0,
+            end_time=8.5,
+        )
+
+        assert result.duration == 3.5
+
+    def test_frozen_immutable(self):
+        """frozen=True によりイミュータブルであることを確認"""
+        result = TranscriptionResult(
+            text="test",
+            start_time=0.0,
+            end_time=1.0,
+        )
+
+        with pytest.raises(FrozenInstanceError):
+            result.text = "modified"  # type: ignore
+
+    def test_to_srt_entry_basic(self):
+        """to_srt_entry の基本テスト"""
+        result = TranscriptionResult(
+            text="テスト文章です。",
+            start_time=0.0,
+            end_time=2.5,
+        )
+
+        srt = result.to_srt_entry(1)
+
+        assert srt == (
+            "1\n"
+            "00:00:00,000 --> 00:00:02,500\n"
+            "テスト文章です。\n"
+        )
+
+    def test_to_srt_entry_long_time(self):
+        """1時間を超える時刻のテスト"""
+        result = TranscriptionResult(
+            text="Long video content",
+            start_time=3661.5,  # 1:01:01.500
+            end_time=3665.123,  # 1:01:05.123
+        )
+
+        srt = result.to_srt_entry(42)
+
+        assert srt == (
+            "42\n"
+            "01:01:01,500 --> 01:01:05,123\n"
+            "Long video content\n"
+        )
+
+    def test_equality(self):
+        """等価性テスト"""
+        result1 = TranscriptionResult(
+            text="same",
+            start_time=0.0,
+            end_time=1.0,
+        )
+        result2 = TranscriptionResult(
+            text="same",
+            start_time=0.0,
+            end_time=1.0,
+        )
+
+        assert result1 == result2
+
+    def test_hashable(self):
+        """ハッシュ可能であることを確認（セットや辞書キーに使用可能）"""
+        result = TranscriptionResult(
+            text="test",
+            start_time=0.0,
+            end_time=1.0,
+        )
+
+        # ハッシュが計算できることを確認
+        hash_value = hash(result)
+        assert isinstance(hash_value, int)
+
+        # セットに追加できることを確認
+        result_set = {result}
+        assert result in result_set
+
+
+class TestInterimResult:
+    """InterimResult のテスト"""
+
+    def test_create_basic(self):
+        """基本的な生成テスト"""
+        interim = InterimResult(
+            text="話している途中",
+            accumulated_time=2.5,
+        )
+
+        assert interim.text == "話している途中"
+        assert interim.accumulated_time == 2.5
+        assert interim.source_id == "default"
+
+    def test_create_with_source_id(self):
+        """source_id 指定のテスト"""
+        interim = InterimResult(
+            text="test",
+            accumulated_time=1.0,
+            source_id="system_audio",
+        )
+
+        assert interim.source_id == "system_audio"
+
+    def test_frozen_immutable(self):
+        """frozen=True によりイミュータブルであることを確認"""
+        interim = InterimResult(
+            text="test",
+            accumulated_time=1.0,
+        )
+
+        with pytest.raises(FrozenInstanceError):
+            interim.text = "modified"  # type: ignore
+
+
+class TestFormatSrtTime:
+    """_format_srt_time 関数のテスト"""
+
+    def test_zero(self):
+        """0秒のテスト"""
+        assert _format_srt_time(0.0) == "00:00:00,000"
+
+    def test_milliseconds(self):
+        """ミリ秒のテスト"""
+        assert _format_srt_time(0.123) == "00:00:00,123"
+        assert _format_srt_time(0.999) == "00:00:00,999"
+
+    def test_seconds(self):
+        """秒のテスト"""
+        assert _format_srt_time(45.0) == "00:00:45,000"
+        assert _format_srt_time(59.999) == "00:00:59,999"
+
+    def test_minutes(self):
+        """分のテスト"""
+        assert _format_srt_time(60.0) == "00:01:00,000"
+        assert _format_srt_time(125.5) == "00:02:05,500"
+
+    def test_hours(self):
+        """時間のテスト"""
+        assert _format_srt_time(3600.0) == "01:00:00,000"
+        assert _format_srt_time(7325.750) == "02:02:05,750"
+
+    def test_negative_clamped_to_zero(self):
+        """負の値は0にクランプされる"""
+        assert _format_srt_time(-5.0) == "00:00:00,000"


### PR DESCRIPTION
## 概要

Phase 1 Step 1: 基盤型の定義を実装しました。

リアルタイム・ファイル文字起こし両方で使用する統一結果型を追加。

## 変更内容

### 追加ファイル

| ファイル | 内容 |
|---------|------|
| `livecap_core/transcription/result.py` | 結果型の定義 |
| `tests/transcription/test_result.py` | ユニットテスト（17件） |

### TranscriptionResult

```python
@dataclass(frozen=True, slots=True)
class TranscriptionResult:
    text: str
    start_time: float
    end_time: float
    is_final: bool = True
    confidence: float = 1.0
    language: str = ""
    source_id: str = "default"
```

### InterimResult

```python
@dataclass(frozen=True, slots=True)
class InterimResult:
    text: str
    accumulated_time: float
    source_id: str = "default"
```

## 設計ポイント

- `frozen=True`: イミュータブル（スレッドセーフ）
- `slots=True`: メモリ効率化
- `to_srt_entry()`: SRT字幕形式への変換メソッド

## テスト結果

```
17 passed in 0.16s
```

## 関連

- Issue #69: [Phase1] リアルタイム文字起こし実装
- 実装計画: `docs/planning/phase1-implementation-plan.md`

## Test plan

- [x] ユニットテスト全件パス
- [x] ruff コードスタイルチェック通過
- [x] インポート動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)