### PR TITLE
test: remove whispers2t_large_v3 VRAM constraint for testing

### DIFF
--- a/tests/integration/engines/test_smoke_engines.py
+++ b/tests/integration/engines/test_smoke_engines.py
@@ -173,7 +173,7 @@ CASES: list[EngineSmokeCase] = [
         audio_stem="librispeech_test-clean_1089-134686-0001_en",
         device="cuda",
         requires_gpu=True,
-        min_vram_gb=16,  # Large model requires more VRAM than 11.6GB Linux GPU
+        # min_vram_gb removed - testing if GPU memory cleanup resolves OOM
     ),
 ]
 


### PR DESCRIPTION
## Summary

- Remove `min_vram_gb=16` constraint from `whispers2t_large_v3_gpu_en` test case
- Verify if GPU memory cleanup (`_cleanup_gpu_memory`) from PR #92 resolves previous CUDA OOM errors

## Background

The `min_vram_gb=16` constraint was added as a workaround for CUDA OOM errors on the Linux runner (11.6GB VRAM). However, PR #92 added GPU memory cleanup between tests, which may have been the actual fix needed.

**Hypothesis**: Previous OOM was caused by VRAM accumulation from earlier tests, not actual model requirements.

**Expected VRAM usage for Whisper large-v3**:
- Model size: ~3GB (FP16)
- Inference peak: ~6-10GB (depends on batch size and audio length)
- Should theoretically fit in 11.6GB

## Expected Results

| Scenario | Action |
|----------|--------|
| Linux passes | Remove constraint permanently ✅ |
| Linux fails (OOM) | Restore constraint with confirmed evidence |

## Test Plan

- [ ] Linux GPU runner: Verify `whispers2t_large_v3_gpu_en` passes or fails with clear OOM error
- [ ] Windows GPU runner: Should continue to pass (24GB VRAM)

Related: #86, #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)