### PR TITLE
ci: add path-based trigger for Integration Tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,6 +4,14 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 3 * * 1"  # Weekly on Mondays at 03:00 UTC
+  pull_request:
+    paths:
+      - 'engines/**'
+      - 'livecap_core/**'
+      - 'tests/integration/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/integration-tests.yml'
 
 jobs:
   transcription-pipeline:


### PR DESCRIPTION
## Summary

Add automatic PR trigger for Integration Tests when relevant files change.

## Trigger Paths

| Path | Description |
|------|-------------|
| `engines/**` | ASR engine implementations |
| `livecap_core/**` | Core library code |
| `tests/integration/**` | Integration test files |
| `pyproject.toml` | Dependencies |
| `uv.lock` | Locked dependencies |
| `.github/workflows/integration-tests.yml` | Workflow itself |

## Behavior

| PR Content | Integration Tests |
|------------|-------------------|
| README.md only | ❌ Not triggered |
| docs/** only | ❌ Not triggered |
| engines/canary_engine.py | ✅ Triggered |
| pyproject.toml | ✅ Triggered |
| tests/integration/** | ✅ Triggered |

## Preserved Triggers

- `workflow_dispatch` - Manual trigger
- `schedule` - Weekly Monday 03:00 UTC

## Test Plan

- [x] This PR itself should trigger Integration Tests (changes `.github/workflows/integration-tests.yml`)
- [ ] Verify Integration Tests run automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)