### PR TITLE
fix(ci): install CUDA-enabled PyTorch for benchmark workflow

### DIFF
--- a/.github/workflows/benchmark-asr.yml
+++ b/.github/workflows/benchmark-asr.yml
@@ -90,17 +90,60 @@ jobs:
         with:
           ffmpeg-bin-dir: ${{ env.LIVECAP_FFMPEG_BIN }}
 
-      - name: Sync dependencies
+      - name: Setup Python environment with CUDA PyTorch
         shell: pwsh
         run: |
-          uv sync --extra engines-torch --extra engines-nemo --extra vad --extra benchmark --extra dev
+          # Clean slate - remove existing venv if present
+          Remove-Item -Recurse -Force .venv -ErrorAction SilentlyContinue
+
+          # Pin Python version to the preinstalled one
+          uv python pin "$Env:PYTHON_EXE"
+
+          # Create venv
+          uv venv
+
+          # Add venv to PATH for subsequent steps
+          echo "$PWD/.venv/Scripts" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+          # 1. Install CUDA-enabled PyTorch FIRST (cu124 for CUDA 12.4)
+          Write-Host "Installing CUDA-enabled PyTorch..."
+          uv pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124
+
+          # 2. Install project dependencies
+          Write-Host "Installing project dependencies..."
+          uv pip install -e ".[engines-torch,engines-nemo,vad,benchmark,dev]"
+
+          # 3. Remove conflicting cuDNN package (may cause issues)
+          Write-Host "Removing conflicting cuDNN package..."
+          uv pip uninstall nvidia-cudnn-cu12 --quiet 2>$null
+
+          Write-Host "Setup complete"
+
+      - name: Verify CUDA availability
+        shell: pwsh
+        run: |
+          Write-Host "=== GPU Info ==="
+          nvidia-smi --query-gpu=name,memory.total --format=csv
+
+          Write-Host "`n=== PyTorch CUDA Check ==="
+          python -c @"
+          import torch
+          print(f'PyTorch version: {torch.__version__}')
+          print(f'CUDA available: {torch.cuda.is_available()}')
+          if torch.cuda.is_available():
+              print(f'CUDA version: {torch.version.cuda}')
+              print(f'Device: {torch.cuda.get_device_name(0)}')
+          else:
+              print('WARNING: CUDA not available!')
+              exit(1)
+          "@
 
       - name: Prepare benchmark data (if standard/full mode)
         if: inputs.mode != 'quick'
         shell: pwsh
         run: |
           Write-Host "Preparing benchmark data for ${{ inputs.mode }} mode..."
-          uv run python scripts/prepare_benchmark_data.py --mode ${{ inputs.mode }}
+          python scripts/prepare_benchmark_data.py --mode ${{ inputs.mode }}
 
       - name: Run ASR Benchmark
         id: benchmark
@@ -121,8 +164,8 @@ jobs:
             $args += $engineList
           }
 
-          Write-Host "Running: uv run python -m benchmarks.asr $($args -join ' ')"
-          uv run python -m benchmarks.asr @args
+          Write-Host "Running: python -m benchmarks.asr $($args -join ' ')"
+          python -m benchmarks.asr @args
 
           # Find the output directory (most recent in benchmark_results/)
           $outputDir = Get-ChildItem -Path "benchmark_results" -Directory | Sort-Object LastWriteTime -Descending | Select-Object -First 1


### PR DESCRIPTION
## Summary

Fix the issue where `uv sync` installs CPU-only PyTorch from PyPI, causing ASR benchmarks to run on CPU instead of GPU (RTX 4090).

## Problem

Quick mode benchmark ran on CPU:
```
PyTorch CPU build detected (2.9.1+cpu); falling back to CPU for Parakeet.
WhisperS2T Large-v3 on CPU will be VERY SLOW!
```

## Solution

Follow the same pattern as `integration-tests.yml` (PR #37):

1. Clean slate: remove existing `.venv`
2. Pin Python version with `uv python pin`
3. Install CUDA PyTorch from official index (cu124) **FIRST**
4. Then install project dependencies with `uv pip install`
5. Add venv to PATH for subsequent steps
6. Remove conflicting `nvidia-cudnn-cu12` package
7. Add CUDA verification step
8. Use `python` directly instead of `uv run python`

## Verification

Added step to verify CUDA availability:
```powershell
nvidia-smi --query-gpu=name,memory.total --format=csv
python -c "import torch; print(torch.cuda.is_available())"
```

## Test plan

- [ ] Merge and run `quick` mode benchmark
- [ ] Verify CUDA is detected (RTX 4090)
- [ ] Run `standard` mode for full benchmark

## Related

- PR #37: Original fix for integration-tests.yml
- Issue #35: Windows GPU runners falling back to CPU

🤖 Generated with [Claude Code](https://claude.com/claude-code)