### PR TITLE
feat(benchmarks): add real-time progress visibility for GitHub Actions

### DIFF
--- a/benchmarks/common/__init__.py
+++ b/benchmarks/common/__init__.py
@@ -38,6 +38,10 @@ from .reports import (
     BenchmarkResult,
     BenchmarkSummary,
 )
+from .progress import (
+    ProgressReporter,
+    EngineProgress,
+)
 
 __all__ = [
     # metrics
@@ -63,4 +67,7 @@ __all__ = [
     "BenchmarkReporter",
     "BenchmarkResult",
     "BenchmarkSummary",
+    # progress
+    "ProgressReporter",
+    "EngineProgress",
 ]

--- a/benchmarks/common/progress.py
+++ b/benchmarks/common/progress.py
@@ -1,0 +1,317 @@
+"""Progress reporting for benchmark execution.
+
+Provides real-time progress visibility in GitHub Actions and local environments.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["ProgressReporter", "EngineProgress"]
+
+
+@dataclass
+class EngineProgress:
+    """Progress data for a single engine benchmark."""
+
+    engine_id: str
+    language: str
+    files_total: int
+    files_completed: int = 0
+    wer: float | None = None
+    cer: float | None = None
+    rtf: float | None = None
+    elapsed_s: float = 0.0
+    status: str = "pending"  # pending, running, completed, skipped, failed
+
+
+@dataclass
+class BenchmarkProgress:
+    """Overall benchmark progress state."""
+
+    benchmark_type: str  # "asr" or "vad"
+    mode: str
+    languages: list[str]
+    engines_total: int
+    engines_completed: int = 0
+    start_time: float = field(default_factory=time.time)
+    engine_progress: list[EngineProgress] = field(default_factory=list)
+
+
+class ProgressReporter:
+    """Reports benchmark progress to GitHub Actions and local console.
+
+    Features:
+    - GitHub Actions: Step Summary 逐次追記、Annotations
+    - Local: tqdm-style progress bar、logger output
+
+    Usage:
+        reporter = ProgressReporter(
+            benchmark_type="asr",
+            mode="full",
+            languages=["ja", "en"],
+            total_engines=10,
+        )
+
+        for engine_id in engines:
+            reporter.engine_started(engine_id, "ja", files_count=100)
+            # ... run benchmark ...
+            reporter.engine_completed(engine_id, wer=0.15, cer=0.08, rtf=0.05)
+
+        reporter.benchmark_completed()
+    """
+
+    def __init__(
+        self,
+        benchmark_type: str,
+        mode: str,
+        languages: list[str],
+        total_engines: int,
+    ) -> None:
+        """Initialize progress reporter.
+
+        Args:
+            benchmark_type: Type of benchmark ("asr" or "vad")
+            mode: Benchmark mode ("quick", "standard", "full")
+            languages: Languages being benchmarked
+            total_engines: Total number of engines to benchmark
+        """
+        self._benchmark_type = benchmark_type
+        self._mode = mode
+        self._languages = languages
+        self._total_engines = total_engines
+
+        # Environment detection
+        self._is_github_actions = bool(os.environ.get("GITHUB_ACTIONS"))
+        self._step_summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+
+        # Progress tracking
+        self._progress = BenchmarkProgress(
+            benchmark_type=benchmark_type,
+            mode=mode,
+            languages=languages,
+            engines_total=total_engines,
+        )
+        self._current_engine: EngineProgress | None = None
+        self._engine_start_time: float = 0.0
+
+        # Initialize Step Summary header if in GitHub Actions
+        if self._is_github_actions and self._step_summary_path:
+            self._init_step_summary()
+
+    def _init_step_summary(self) -> None:
+        """Initialize GitHub Step Summary with header."""
+        header = f"""## {self._benchmark_type.upper()} Benchmark Progress
+
+**Mode:** {self._mode} | **Languages:** {', '.join(self._languages)} | **Engines:** {self._total_engines}
+
+| # | Engine | Language | Files | WER | CER | RTF | Time | Status |
+|---|--------|----------|-------|-----|-----|-----|------|--------|
+"""
+        self._write_step_summary(header)
+
+    def _write_step_summary(self, content: str) -> None:
+        """Append content to GitHub Step Summary."""
+        if not self._step_summary_path:
+            return
+        try:
+            with open(self._step_summary_path, "a", encoding="utf-8") as f:
+                f.write(content)
+        except OSError as e:
+            logger.debug(f"Failed to write to step summary: {e}")
+
+    def _emit_notice(self, message: str) -> None:
+        """Emit GitHub Actions notice annotation."""
+        if self._is_github_actions:
+            # GitHub Actions workflow command
+            print(f"::notice::{message}")
+        logger.info(message)
+
+    def _emit_warning(self, message: str) -> None:
+        """Emit GitHub Actions warning annotation."""
+        if self._is_github_actions:
+            print(f"::warning::{message}")
+        logger.warning(message)
+
+    def _format_time(self, seconds: float) -> str:
+        """Format seconds as human-readable time."""
+        if seconds < 60:
+            return f"{seconds:.0f}s"
+        elif seconds < 3600:
+            mins = int(seconds // 60)
+            secs = int(seconds % 60)
+            return f"{mins}m{secs}s"
+        else:
+            hours = int(seconds // 3600)
+            mins = int((seconds % 3600) // 60)
+            return f"{hours}h{mins}m"
+
+    def _get_elapsed(self) -> float:
+        """Get elapsed time since benchmark start."""
+        return time.time() - self._progress.start_time
+
+    def _estimate_remaining(self) -> float | None:
+        """Estimate remaining time based on completed engines."""
+        if self._progress.engines_completed == 0:
+            return None
+        avg_time = self._get_elapsed() / self._progress.engines_completed
+        remaining = self._total_engines - self._progress.engines_completed
+        return avg_time * remaining
+
+    def benchmark_started(self) -> None:
+        """Called when benchmark execution starts."""
+        self._progress.start_time = time.time()
+        message = (
+            f"Starting {self._benchmark_type.upper()} benchmark "
+            f"(mode={self._mode}, engines={self._total_engines})"
+        )
+        self._emit_notice(message)
+
+    def engine_started(
+        self,
+        engine_id: str,
+        language: str,
+        files_count: int,
+    ) -> None:
+        """Called when an engine benchmark starts.
+
+        Args:
+            engine_id: Engine identifier
+            language: Language being benchmarked
+            files_count: Number of files to process
+        """
+        self._engine_start_time = time.time()
+        self._current_engine = EngineProgress(
+            engine_id=engine_id,
+            language=language,
+            files_total=files_count,
+            status="running",
+        )
+
+        idx = self._progress.engines_completed + 1
+        message = (
+            f"[{idx}/{self._total_engines}] Starting {engine_id} "
+            f"({language}, {files_count} files)"
+        )
+        logger.info(message)
+
+    def file_completed(self) -> None:
+        """Called when a single file is processed."""
+        if self._current_engine:
+            self._current_engine.files_completed += 1
+
+    def engine_completed(
+        self,
+        engine_id: str,
+        wer: float | None = None,
+        cer: float | None = None,
+        rtf: float | None = None,
+    ) -> None:
+        """Called when an engine benchmark completes.
+
+        Args:
+            engine_id: Engine identifier
+            wer: Word Error Rate (0.0-1.0)
+            cer: Character Error Rate (0.0-1.0)
+            rtf: Real-Time Factor
+        """
+        elapsed = time.time() - self._engine_start_time
+        self._progress.engines_completed += 1
+        idx = self._progress.engines_completed
+
+        if self._current_engine:
+            self._current_engine.wer = wer
+            self._current_engine.cer = cer
+            self._current_engine.rtf = rtf
+            self._current_engine.elapsed_s = elapsed
+            self._current_engine.status = "completed"
+            self._progress.engine_progress.append(self._current_engine)
+
+        # Format metrics
+        wer_str = f"{wer:.1%}" if wer is not None else "-"
+        cer_str = f"{cer:.1%}" if cer is not None else "-"
+        rtf_str = f"{rtf:.2f}x" if rtf is not None else "-"
+        time_str = self._format_time(elapsed)
+
+        # Console message
+        remaining = self._estimate_remaining()
+        remaining_str = f", ETA: {self._format_time(remaining)}" if remaining else ""
+        message = (
+            f"[{idx}/{self._total_engines}] ✅ {engine_id} completed - "
+            f"WER: {wer_str}, RTF: {rtf_str}, Time: {time_str}{remaining_str}"
+        )
+        self._emit_notice(message)
+
+        # GitHub Step Summary row
+        if self._is_github_actions and self._current_engine:
+            files_str = f"{self._current_engine.files_completed}/{self._current_engine.files_total}"
+            row = (
+                f"| {idx} | {engine_id} | {self._current_engine.language} | "
+                f"{files_str} | {wer_str} | {cer_str} | {rtf_str} | {time_str} | ✅ |\n"
+            )
+            self._write_step_summary(row)
+
+        self._current_engine = None
+
+    def engine_skipped(self, engine_id: str, reason: str) -> None:
+        """Called when an engine is skipped.
+
+        Args:
+            engine_id: Engine identifier
+            reason: Skip reason
+        """
+        self._progress.engines_completed += 1
+        idx = self._progress.engines_completed
+
+        message = f"[{idx}/{self._total_engines}] ⏭️ {engine_id} skipped: {reason}"
+        self._emit_warning(message)
+
+        # GitHub Step Summary row
+        if self._is_github_actions:
+            row = f"| {idx} | {engine_id} | - | - | - | - | - | - | ⏭️ |\n"
+            self._write_step_summary(row)
+
+    def engine_failed(self, engine_id: str, error: str) -> None:
+        """Called when an engine benchmark fails.
+
+        Args:
+            engine_id: Engine identifier
+            error: Error message
+        """
+        elapsed = time.time() - self._engine_start_time
+        self._progress.engines_completed += 1
+        idx = self._progress.engines_completed
+
+        message = f"[{idx}/{self._total_engines}] ❌ {engine_id} failed: {error}"
+        self._emit_warning(message)
+
+        # GitHub Step Summary row
+        if self._is_github_actions:
+            time_str = self._format_time(elapsed)
+            row = f"| {idx} | {engine_id} | - | - | - | - | - | {time_str} | ❌ |\n"
+            self._write_step_summary(row)
+
+        self._current_engine = None
+
+    def benchmark_completed(self) -> None:
+        """Called when benchmark execution completes."""
+        total_elapsed = self._get_elapsed()
+        completed = self._progress.engines_completed
+
+        message = (
+            f"Benchmark completed: {completed}/{self._total_engines} engines, "
+            f"Total time: {self._format_time(total_elapsed)}"
+        )
+        self._emit_notice(message)
+
+        # GitHub Step Summary footer
+        if self._is_github_actions:
+            footer = f"\n**Total time:** {self._format_time(total_elapsed)}\n"
+            self._write_step_summary(footer)

--- a/tests/benchmark_tests/common/test_progress.py
+++ b/tests/benchmark_tests/common/test_progress.py
@@ -1,0 +1,220 @@
+"""Unit tests for ProgressReporter."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from unittest import mock
+
+import pytest
+
+from benchmarks.common.progress import EngineProgress, ProgressReporter
+
+
+class TestProgressReporter:
+    """ProgressReporter テスト"""
+
+    def test_init_local_environment(self):
+        """ローカル環境での初期化"""
+        with mock.patch.dict(os.environ, {}, clear=True):
+            reporter = ProgressReporter(
+                benchmark_type="asr",
+                mode="quick",
+                languages=["ja", "en"],
+                total_engines=4,
+            )
+            assert reporter._is_github_actions is False
+            assert reporter._step_summary_path is None
+
+    def test_init_github_actions_environment(self):
+        """GitHub Actions 環境での初期化"""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".md") as f:
+            summary_path = f.name
+
+        try:
+            with mock.patch.dict(
+                os.environ,
+                {"GITHUB_ACTIONS": "true", "GITHUB_STEP_SUMMARY": summary_path},
+            ):
+                reporter = ProgressReporter(
+                    benchmark_type="asr",
+                    mode="full",
+                    languages=["ja"],
+                    total_engines=10,
+                )
+                assert reporter._is_github_actions is True
+                assert reporter._step_summary_path == summary_path
+
+                # Check that header was written
+                with open(summary_path) as f:
+                    content = f.read()
+                assert "ASR Benchmark Progress" in content
+                assert "full" in content
+                assert "10" in content
+        finally:
+            os.unlink(summary_path)
+
+    def test_format_time_seconds(self):
+        """時間フォーマット（秒）"""
+        reporter = ProgressReporter("asr", "quick", ["ja"], 1)
+        assert reporter._format_time(30) == "30s"
+        assert reporter._format_time(59) == "59s"
+
+    def test_format_time_minutes(self):
+        """時間フォーマット（分）"""
+        reporter = ProgressReporter("asr", "quick", ["ja"], 1)
+        assert reporter._format_time(60) == "1m0s"
+        assert reporter._format_time(90) == "1m30s"
+        assert reporter._format_time(3599) == "59m59s"
+
+    def test_format_time_hours(self):
+        """時間フォーマット（時間）"""
+        reporter = ProgressReporter("asr", "quick", ["ja"], 1)
+        assert reporter._format_time(3600) == "1h0m"
+        assert reporter._format_time(7200) == "2h0m"
+        assert reporter._format_time(5400) == "1h30m"
+
+    def test_engine_started(self, capsys):
+        """エンジン開始報告"""
+        reporter = ProgressReporter("asr", "quick", ["ja"], 2)
+        reporter.engine_started("parakeet_ja", "ja", 100)
+
+        assert reporter._current_engine is not None
+        assert reporter._current_engine.engine_id == "parakeet_ja"
+        assert reporter._current_engine.language == "ja"
+        assert reporter._current_engine.files_total == 100
+        assert reporter._current_engine.status == "running"
+
+    def test_engine_completed(self, capsys):
+        """エンジン完了報告"""
+        reporter = ProgressReporter("asr", "quick", ["ja"], 2)
+        reporter.engine_started("parakeet_ja", "ja", 100)
+        reporter.engine_completed("parakeet_ja", wer=0.15, cer=0.08, rtf=0.05)
+
+        assert reporter._progress.engines_completed == 1
+        assert len(reporter._progress.engine_progress) == 1
+
+        progress = reporter._progress.engine_progress[0]
+        assert progress.wer == 0.15
+        assert progress.cer == 0.08
+        assert progress.rtf == 0.05
+        assert progress.status == "completed"
+
+    def test_engine_skipped(self, capsys):
+        """エンジンスキップ報告"""
+        reporter = ProgressReporter("asr", "quick", ["ja"], 2)
+        reporter.engine_skipped("voxtral", "Does not support ja")
+
+        assert reporter._progress.engines_completed == 1
+
+    def test_engine_failed(self, capsys):
+        """エンジン失敗報告"""
+        reporter = ProgressReporter("asr", "quick", ["ja"], 2)
+        reporter.engine_started("parakeet_ja", "ja", 100)
+        reporter.engine_failed("parakeet_ja", "CUDA out of memory")
+
+        assert reporter._progress.engines_completed == 1
+        assert reporter._current_engine is None
+
+    def test_file_completed(self):
+        """ファイル完了報告"""
+        reporter = ProgressReporter("asr", "quick", ["ja"], 1)
+        reporter.engine_started("parakeet_ja", "ja", 100)
+
+        assert reporter._current_engine.files_completed == 0
+        reporter.file_completed()
+        assert reporter._current_engine.files_completed == 1
+        reporter.file_completed()
+        assert reporter._current_engine.files_completed == 2
+
+    def test_benchmark_completed(self, capsys):
+        """ベンチマーク完了報告"""
+        reporter = ProgressReporter("asr", "quick", ["ja"], 2)
+        reporter.benchmark_started()
+        reporter.engine_started("engine1", "ja", 10)
+        reporter.engine_completed("engine1", wer=0.1, cer=0.05, rtf=0.1)
+        reporter.engine_started("engine2", "ja", 10)
+        reporter.engine_completed("engine2", wer=0.2, cer=0.1, rtf=0.2)
+        reporter.benchmark_completed()
+
+        assert reporter._progress.engines_completed == 2
+
+    def test_github_actions_step_summary(self):
+        """GitHub Actions Step Summary への書き込み"""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".md") as f:
+            summary_path = f.name
+
+        try:
+            with mock.patch.dict(
+                os.environ,
+                {"GITHUB_ACTIONS": "true", "GITHUB_STEP_SUMMARY": summary_path},
+            ):
+                reporter = ProgressReporter("asr", "full", ["ja"], 2)
+                reporter.benchmark_started()
+                reporter.engine_started("parakeet_ja", "ja", 100)
+                for _ in range(100):
+                    reporter.file_completed()
+                reporter.engine_completed("parakeet_ja", wer=0.15, cer=0.08, rtf=0.05)
+
+                # Read and verify summary content
+                with open(summary_path) as f:
+                    content = f.read()
+
+                # Header should be present
+                assert "ASR Benchmark Progress" in content
+                # Engine row should be present
+                assert "parakeet_ja" in content
+                assert "15.0%" in content  # WER
+                assert "0.05x" in content  # RTF
+                assert "100/100" in content  # files
+                assert "✅" in content  # status
+        finally:
+            os.unlink(summary_path)
+
+    def test_estimate_remaining(self):
+        """残り時間推定"""
+        reporter = ProgressReporter("asr", "quick", ["ja"], 4)
+        reporter.benchmark_started()
+
+        # No completed engines yet
+        assert reporter._estimate_remaining() is None
+
+        # After completing 2 engines
+        reporter._progress.engines_completed = 2
+        remaining = reporter._estimate_remaining()
+        assert remaining is not None
+
+
+class TestEngineProgress:
+    """EngineProgress テスト"""
+
+    def test_default_values(self):
+        """デフォルト値"""
+        progress = EngineProgress(
+            engine_id="test_engine",
+            language="ja",
+            files_total=100,
+        )
+        assert progress.files_completed == 0
+        assert progress.wer is None
+        assert progress.cer is None
+        assert progress.rtf is None
+        assert progress.elapsed_s == 0.0
+        assert progress.status == "pending"
+
+    def test_custom_values(self):
+        """カスタム値"""
+        progress = EngineProgress(
+            engine_id="test_engine",
+            language="en",
+            files_total=50,
+            files_completed=25,
+            wer=0.15,
+            cer=0.08,
+            rtf=0.05,
+            elapsed_s=120.5,
+            status="completed",
+        )
+        assert progress.files_completed == 25
+        assert progress.wer == 0.15
+        assert progress.status == "completed"


### PR DESCRIPTION
## Summary

ASR Benchmark の full mode 実行時、GitHub Actions 上でリアルタイムに進捗を確認できるようになります。

- 各エンジン完了時に **Step Summary** へ逐次追記
- **::notice::** アノテーションで進捗通知
- 経過時間・残り推定時間（ETA）の表示

### Step Summary 出力例

| # | Engine | Language | Files | WER | CER | RTF | Time | Status |
|---|--------|----------|-------|-----|-----|-----|------|--------|
| 1 | parakeet_ja | ja | 100/100 | 15.0% | 8.0% | 0.05x | 5m30s | ✅ |
| 2 | whispers2t_large_v3 | ja | 100/100 | 12.5% | 6.2% | 0.08x | 8m15s | ✅ |

### Console 出力例

```
[1/10] Starting parakeet_ja (ja, 100 files)
[1/10] ✅ parakeet_ja completed - WER: 15.0%, RTF: 0.05x, Time: 5m30s, ETA: 49m30s
```

## Changes

- `benchmarks/common/progress.py`: 新規 `ProgressReporter` クラス
- `benchmarks/asr/runner.py`: 進捗報告の統合
- `tests/benchmark_tests/common/test_progress.py`: ユニットテスト（15 tests）

## Test plan

- [x] Unit tests pass (53 benchmark tests)
- [ ] CI tests pass
- [ ] Manual verification in GitHub Actions (next benchmark run)

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)