### PR TITLE
fix(tests): prevent benchmark tests from writing to real Step Summary

### DIFF
--- a/tests/benchmark_tests/common/test_progress.py
+++ b/tests/benchmark_tests/common/test_progress.py
@@ -10,18 +10,7 @@ import pytest
 
 from benchmarks.common.progress import EngineProgress, ProgressReporter
 
-
-@pytest.fixture(autouse=True)
-def clean_github_env():
-    """Ensure GitHub Actions environment variables are cleared for all tests.
-
-    This prevents tests from accidentally writing to the real GITHUB_STEP_SUMMARY.
-    """
-    with mock.patch.dict(
-        os.environ,
-        {"GITHUB_ACTIONS": "", "GITHUB_STEP_SUMMARY": ""},
-    ):
-        yield
+# Note: clean_github_env fixture is provided by tests/benchmark_tests/conftest.py
 
 
 class TestProgressReporter:

--- a/tests/benchmark_tests/conftest.py
+++ b/tests/benchmark_tests/conftest.py
@@ -1,0 +1,22 @@
+"""Shared fixtures for benchmark tests."""
+
+from __future__ import annotations
+
+import os
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_github_env():
+    """Ensure GitHub Actions environment variables are cleared for all benchmark tests.
+
+    This prevents tests from accidentally writing to the real GITHUB_STEP_SUMMARY
+    when ProgressReporter is initialized during test execution.
+    """
+    with mock.patch.dict(
+        os.environ,
+        {"GITHUB_ACTIONS": "", "GITHUB_STEP_SUMMARY": ""},
+    ):
+        yield


### PR DESCRIPTION
## Summary

Benchmark tests were accidentally writing to the real `GITHUB_STEP_SUMMARY` during CI runs, causing "ASR Benchmark Progress" tables to appear in unrelated test results.

## Root Cause

The `clean_github_env` autouse fixture was defined only in `test_progress.py`, so it only affected tests in that file. Tests in `test_runner.py` that call `ASRBenchmarkRunner.run()` were not covered, and `ProgressReporter` was writing to the real Step Summary.

## Solution

Move the `clean_github_env` fixture to `tests/benchmark_tests/conftest.py` so it applies to **all** benchmark tests automatically.

```python
# tests/benchmark_tests/conftest.py
@pytest.fixture(autouse=True)
def clean_github_env():
    with mock.patch.dict(os.environ, {"GITHUB_ACTIONS": "", "GITHUB_STEP_SUMMARY": ""}):
        yield
```

## Test plan

- [x] All 53 benchmark tests pass locally
- [ ] CI tests pass without Step Summary pollution

🤖 Generated with [Claude Code](https://claude.com/claude-code)