### PR TITLE
docs: Phase C-2 VADBenchmarkRunner design decisions

### DIFF
--- a/docs/planning/vad-benchmark-plan.md
+++ b/docs/planning/vad-benchmark-plan.md
@@ -463,8 +463,11 @@ VAD が悪い → 音声の切り落とし/ノイズ混入 → ASR 精度が低�
 ```
 
 **将来の拡張（必要に応じて）:**
+- AVA-Speech 等のラベル付きデータセットによる直接評価（Precision, Recall, F1）
 - 基準 VAD（例: Silero）との交差比較（IoU, Segment Agreement Rate）
 - 手動アノテーションによるサブセット評価
+
+> 📝 詳細は Issue #86 の調査メモ「VAD 評価手法の調査メモ」を参照
 
 ### 6.4 Raw vs Normalized メトリクス（Phase B 実装予定）
 
@@ -1999,6 +2002,23 @@ benchmark = [
 
 - de, fr, es などの追加言語
 - 言語検出精度の評価
+
+### 14.4 VAD 直接評価
+
+ラベル付きデータセットを使用した VAD 単体の精度評価:
+
+| データセット | 特徴 | メトリクス |
+|-------------|------|-----------|
+| [AVA-Speech](https://arxiv.org/abs/1808.00606) | 映画音声、3種ラベル | Precision, Recall, F1 |
+| [LibriParty](https://huggingface.co/speechbrain/vad-crdnn-libriparty) | 重複発話シミュレーション | ROC-AUC |
+
+**実装案:**
+```bash
+# AVA-Speech による直接評価
+python -m benchmarks.vad --mode direct --dataset ava-speech
+```
+
+> 📝 詳細は Issue #86 の調査メモ「VAD 評価手法の調査メモ」Option A を参照
 
 ---
 


### PR DESCRIPTION
## Summary

Phase C-2 (VADBenchmarkRunner 実装) に向けた設計決定をドキュメント化。

### 変更内容

**VAD 構成数の修正:**
- 10構成 → 9構成（Silero v5 は v6 上位互換のため除外）
- 評価マトリクス、モード説明の数値を更新

**C-2 VADBenchmarkRunner 設計:**
- `VADBenchmarkBackend` Protocol（ベンチマーク専用統一インターフェース）
- `VADProcessorWrapper`（Protocol準拠 VAD のラッパー）
- セグメント結合戦略（言語別）

**BenchmarkResult 拡張フィールド:**
- `vad_rtf`: VAD 処理の RTF
- `segments_count`: 検出セグメント数
- `avg_segment_duration_s`: 平均セグメント長
- `speech_ratio` は将来検討（C-2 では見送り）

**ProgressReporter 拡張:**
- 既存 ProgressReporter を拡張（`vad_name` パラメータ追加）
- Step Summary に VAD 列を追加

**CI ワークフロー設計:**
- 統合 → 分離方式に変更
- `asr-benchmark.yml`: ASR エンジン比較（VAD は Silero 固定）
- `vad-benchmark.yml`: VAD バックエンド比較（ASR は言語別固定）

**Phase C ステータス更新:**
- C-1: ✅ 完了 (PR #110, #114)
- C-2: 🔜 次

## Test plan

- [x] ドキュメントの整合性確認
- [x] VAD構成数（9）の一貫性確認

Related: #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)