### PR TITLE
refactor(benchmarks): standard mode uses quick defaults for engines/VADs

### DIFF
--- a/benchmarks/asr/runner.py
+++ b/benchmarks/asr/runner.py
@@ -79,10 +79,10 @@ class ASRBenchmarkConfig:
         if self.engines:
             return self.engines
 
-        if self.mode == "quick":
+        if self.mode in ("quick", "standard"):
             return QUICK_MODE_ENGINES.get(language, [])
 
-        # standard/full: use all engines for this language
+        # full: use all engines for this language
         return BenchmarkEngineManager.get_engines_for_language(language)
 
 

--- a/benchmarks/vad/runner.py
+++ b/benchmarks/vad/runner.py
@@ -89,10 +89,10 @@ class VADBenchmarkConfig:
         if self.engines:
             return self.engines
 
-        if self.mode == "quick":
+        if self.mode in ("quick", "standard"):
             return QUICK_MODE_ENGINES.get(language, [])
 
-        # standard/full: use all engines for this language
+        # full: use all engines for this language
         return BenchmarkEngineManager.get_engines_for_language(language)
 
     def get_vads(self) -> list[str]:
@@ -104,10 +104,10 @@ class VADBenchmarkConfig:
         if self.vads:
             return self.vads
 
-        if self.mode == "quick":
+        if self.mode in ("quick", "standard"):
             return QUICK_MODE_VADS
 
-        # standard/full: use all VADs
+        # full: use all VADs
         return get_all_vad_ids()
 
 

--- a/tests/benchmark_tests/asr/test_runner.py
+++ b/tests/benchmark_tests/asr/test_runner.py
@@ -75,12 +75,24 @@ class TestASRBenchmarkConfig:
         assert config.get_engines_for_language("ja") == ["reazonspeech", "parakeet_ja"]
         assert config.get_engines_for_language("en") == ["reazonspeech", "parakeet_ja"]
 
+    def test_get_engines_for_language_standard_mode_ja(self) -> None:
+        """Test engine selection for standard mode uses quick defaults for Japanese."""
+        config = ASRBenchmarkConfig(mode="standard")
+        engines = config.get_engines_for_language("ja")
+        assert engines == ["parakeet_ja", "whispers2t_large_v3"]
+
+    def test_get_engines_for_language_standard_mode_en(self) -> None:
+        """Test engine selection for standard mode uses quick defaults for English."""
+        config = ASRBenchmarkConfig(mode="standard")
+        engines = config.get_engines_for_language("en")
+        assert engines == ["parakeet", "whispers2t_large_v3"]
+
     @patch("benchmarks.asr.runner.BenchmarkEngineManager.get_engines_for_language")
-    def test_get_engines_for_language_standard_mode(self, mock_get_engines: MagicMock) -> None:
-        """Test engine selection for standard mode uses all engines for language."""
+    def test_get_engines_for_language_full_mode(self, mock_get_engines: MagicMock) -> None:
+        """Test engine selection for full mode uses all engines for language."""
         mock_get_engines.return_value = ["engine_a", "engine_b", "engine_c"]
 
-        config = ASRBenchmarkConfig(mode="standard")
+        config = ASRBenchmarkConfig(mode="full")
         engines = config.get_engines_for_language("ja")
 
         mock_get_engines.assert_called_once_with("ja")

--- a/tests/benchmark_tests/vad/test_runner.py
+++ b/tests/benchmark_tests/vad/test_runner.py
@@ -96,23 +96,41 @@ class TestVADBenchmarkConfig:
         )
         assert config.get_vads() == ["silero", "tenvad"]
 
+    def test_get_vads_standard_mode_uses_quick_defaults(self) -> None:
+        """Test VAD selection for standard mode uses quick defaults."""
+        config = VADBenchmarkConfig(mode="standard")
+        vads = config.get_vads()
+        assert vads == ["silero", "webrtc_mode3"]
+
     @patch("benchmarks.vad.runner.get_all_vad_ids")
-    def test_get_vads_standard_mode_returns_all(self, mock_get_vads: MagicMock) -> None:
-        """Test VAD selection for standard/full mode uses all VADs."""
+    def test_get_vads_full_mode_returns_all(self, mock_get_vads: MagicMock) -> None:
+        """Test VAD selection for full mode uses all VADs."""
         mock_get_vads.return_value = ["vad_a", "vad_b", "vad_c"]
 
-        config = VADBenchmarkConfig(mode="standard")
+        config = VADBenchmarkConfig(mode="full")
         vads = config.get_vads()
 
         mock_get_vads.assert_called_once()
         assert vads == ["vad_a", "vad_b", "vad_c"]
 
-    @patch("benchmarks.asr.runner.BenchmarkEngineManager.get_engines_for_language")
-    def test_get_engines_for_language_standard_mode(self, mock_get_engines: MagicMock) -> None:
-        """Test engine selection for standard mode uses all engines for language."""
+    def test_get_engines_for_language_standard_mode_ja(self) -> None:
+        """Test engine selection for standard mode uses quick defaults for Japanese."""
+        config = VADBenchmarkConfig(mode="standard")
+        engines = config.get_engines_for_language("ja")
+        assert engines == ["parakeet_ja", "whispers2t_large_v3"]
+
+    def test_get_engines_for_language_standard_mode_en(self) -> None:
+        """Test engine selection for standard mode uses quick defaults for English."""
+        config = VADBenchmarkConfig(mode="standard")
+        engines = config.get_engines_for_language("en")
+        assert engines == ["parakeet", "whispers2t_large_v3"]
+
+    @patch("benchmarks.vad.runner.BenchmarkEngineManager.get_engines_for_language")
+    def test_get_engines_for_language_full_mode(self, mock_get_engines: MagicMock) -> None:
+        """Test engine selection for full mode uses all engines for language."""
         mock_get_engines.return_value = ["engine_a", "engine_b", "engine_c"]
 
-        config = VADBenchmarkConfig(mode="standard")
+        config = VADBenchmarkConfig(mode="full")
         engines = config.get_engines_for_language("ja")
 
         mock_get_engines.assert_called_once_with("ja")


### PR DESCRIPTION
## Summary
- Change standard mode to use quick mode defaults for engines/VADs
- Only full mode now uses all engines and VADs combinations

## Mode behavior (after)

| Mode | Engines/VADs | Dataset |
|------|--------------|---------|
| quick | Default (2×2) | Test audio |
| standard | Default (2×2) | 100 files/lang |
| full | All combinations | All files |

## Benefit
- Standard mode: 135 → 8 combinations (~17x faster)
- Clear role separation:
  - quick/standard = Representative combinations for accuracy testing
  - full = Comprehensive evaluation of all combinations

## Test plan
- [x] All 102 benchmark tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)