### PR TITLE
fix(vad): TenVAD reset() now recreates instance

### DIFF
--- a/livecap_core/vad/backends/tenvad.py
+++ b/livecap_core/vad/backends/tenvad.py
@@ -105,9 +105,13 @@ class TenVAD:
         return float(prob)
 
     def reset(self) -> None:
-        """内部状態をリセット"""
-        if self._vad is not None:
-            self._vad.reset()
+        """内部状態をリセット
+
+        Note: ten_vad.TenVad doesn't have a reset() method,
+        so we recreate the instance to reset internal state.
+        """
+        # Recreate TenVad instance to reset internal state
+        self._initialize()
 
     @property
     def frame_size(self) -> int:

--- a/tests/vad/test_backends.py
+++ b/tests/vad/test_backends.py
@@ -141,3 +141,8 @@ class TestTenVAD:
                     TenVAD(hop_size=200)
         except OSError as e:
             pytest.skip(f"ten-vad native library not available: {e}")
+
+    def test_reset_does_not_raise(self, tenvad):
+        """reset() が例外を発生させない"""
+        # ten_vad.TenVad has no reset() method, so our wrapper recreates the instance
+        tenvad.reset()  # Should not raise


### PR DESCRIPTION
## Summary
- Fix TenVAD `reset()` method that was causing `AttributeError` during VAD benchmark

## Problem
```
'TenVad' object has no attribute 'reset'
```

The external `ten_vad.TenVad` class (from the ten-vad library) doesn't have a `reset()` method, but our wrapper was calling `self._vad.reset()`.

## Solution
Recreate the `TenVad` instance in `reset()` instead of calling the non-existent method.

```python
def reset(self) -> None:
    # Recreate TenVad instance to reset internal state
    self._initialize()
```

## Test plan
- [x] Add test for `reset()` method
- [x] All 156 VAD/benchmark tests pass
- [ ] CI passes
- [ ] Trigger VAD Benchmark with TenVAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)