### PR TITLE
fix(vad): clamp segment start_time to non-negative values

### DIFF
--- a/benchmarks/vad/runner.py
+++ b/benchmarks/vad/runner.py
@@ -409,10 +409,12 @@ class VADBenchmarkRunner:
             segments = vad.process_audio(first_file.audio, first_file.sample_rate)
             if segments:
                 start_s, end_s = segments[0]
-                start_sample = int(start_s * first_file.sample_rate)
-                end_sample = int(end_s * first_file.sample_rate)
+                # Clamp start time to valid range (handles negative timestamps)
+                start_sample = max(0, int(start_s * first_file.sample_rate))
+                end_sample = min(len(first_file.audio), int(end_s * first_file.sample_rate))
                 segment_audio = first_file.audio[start_sample:end_sample]
-                engine.transcribe(segment_audio, first_file.sample_rate)
+                if len(segment_audio) > 0:
+                    engine.transcribe(segment_audio, first_file.sample_rate)
         except Exception as e:
             reason = f"Warm-up failed - {e}"
             logger.warning(f"{engine_id}+{vad_id}: {reason}")
@@ -548,8 +550,9 @@ class VADBenchmarkRunner:
                 run_start = time.perf_counter()
 
                 for start_s, end_s in segments:
-                    start_sample = int(start_s * sample_rate)
-                    end_sample = int(end_s * sample_rate)
+                    # Clamp start time to valid range (handles negative timestamps)
+                    start_sample = max(0, int(start_s * sample_rate))
+                    end_sample = min(len(audio), int(end_s * sample_rate))
                     segment_audio = audio[start_sample:end_sample]
 
                     if len(segment_audio) > 0:

--- a/livecap_core/vad/state_machine.py
+++ b/livecap_core/vad/state_machine.py
@@ -137,8 +137,11 @@ class VADStateMachine:
         if is_speech:
             self._transition_to(VADState.POTENTIAL_SPEECH)
             self._speech_frames = 1
-            self._segment_start_time = timestamp - (
-                len(self._pre_buffer) * self.FRAME_MS / 1000
+            # Calculate start time with pre-buffer padding
+            # Clamp to 0 to avoid negative timestamps (can occur at stream start)
+            self._segment_start_time = max(
+                0.0,
+                timestamp - (len(self._pre_buffer) * self.FRAME_MS / 1000),
             )
             # プリバッファをスピーチバッファにコピー
             self._speech_buffer = list(self._pre_buffer)


### PR DESCRIPTION
## Summary

Fixes the "zero-size array to reduction operation maximum which has no identity" error in VAD Benchmark when using TenVAD.

**Root cause identified through staged debugging:**
- When speech is detected at the start of an audio stream, the pre-buffer padding calculation could produce negative start times (e.g., `timestamp=0.016s - pre_buffer=0.096s = -0.08s`)
- This caused negative array indices in the benchmark runner
- Empty audio segments were passed to ASR engines
- `np.max()` called on empty arrays, causing the numpy error

## Changes

- **`livecap_core/vad/state_machine.py`**: Clamp `start_time` to `max(0, ...)` in `_handle_silence()`
- **`benchmarks/vad/runner.py`**: Add defensive bounds checking for segment slicing in both warm-up and benchmark loops
- **`tests/vad/test_state_machine.py`**: Add regression tests for negative start_time edge cases

## Test plan

- [x] Run `pytest tests/vad/test_state_machine.py` - 17 tests pass including new edge case tests
- [ ] Run VAD Benchmark with TenVAD to verify fix

## Investigation details

Debug workflow run showing all VAD pipeline stages work correctly with synthesized audio:
- https://github.com/Mega-Gorilla/livecap-core/actions/runs/19755243850

The issue only occurred with real audio files where speech detection happened immediately at stream start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)