### PR TITLE
refactor(benchmark): remove webrtc_mode* variants from VAD registry

### DIFF
--- a/benchmarks/vad/cli.py
+++ b/benchmarks/vad/cli.py
@@ -2,7 +2,7 @@
 
 Usage:
     python -m benchmarks.vad --mode quick
-    python -m benchmarks.vad --engine parakeet_ja --vad silero webrtc_mode3 --language ja
+    python -m benchmarks.vad --engine parakeet_ja --vad silero webrtc --language ja
     python -m benchmarks.vad --mode standard --runs 3
     python -m benchmarks.vad --mode standard --param-source preset --language ja
 """
@@ -56,7 +56,7 @@ Examples:
   python -m benchmarks.vad --mode quick
 
   # Benchmark specific VADs with a specific engine
-  python -m benchmarks.vad --engine parakeet_ja --vad silero webrtc_mode3 --language ja
+  python -m benchmarks.vad --engine parakeet_ja --vad silero webrtc --language ja
 
   # Full benchmark with multiple runs
   python -m benchmarks.vad --mode full --runs 3

--- a/benchmarks/vad/factory.py
+++ b/benchmarks/vad/factory.py
@@ -24,36 +24,14 @@ VAD_REGISTRY: dict[str, dict[str, Any]] = {
         "module": "livecap_core.vad.backends.silero",
         "params": {"threshold": 0.5, "onnx": True},
     },
-    # WebRTC base entry (mode specified via backend_params, used by presets)
+    # WebRTC VAD (mode specified via backend_params)
+    # Mode 0-3: aggressiveness level (0=quality, 3=aggressive)
+    # Use backend_params={"mode": N} to override default
     "webrtc": {
         "type": "protocol",
         "backend_class": "WebRTCVAD",
         "module": "livecap_core.vad.backends.webrtc",
         "params": {"mode": 0, "frame_duration_ms": 20},
-    },
-    "webrtc_mode0": {
-        "type": "protocol",
-        "backend_class": "WebRTCVAD",
-        "module": "livecap_core.vad.backends.webrtc",
-        "params": {"mode": 0, "frame_duration_ms": 20},
-    },
-    "webrtc_mode1": {
-        "type": "protocol",
-        "backend_class": "WebRTCVAD",
-        "module": "livecap_core.vad.backends.webrtc",
-        "params": {"mode": 1, "frame_duration_ms": 20},
-    },
-    "webrtc_mode2": {
-        "type": "protocol",
-        "backend_class": "WebRTCVAD",
-        "module": "livecap_core.vad.backends.webrtc",
-        "params": {"mode": 2, "frame_duration_ms": 20},
-    },
-    "webrtc_mode3": {
-        "type": "protocol",
-        "backend_class": "WebRTCVAD",
-        "module": "livecap_core.vad.backends.webrtc",
-        "params": {"mode": 3, "frame_duration_ms": 20},
     },
     "tenvad": {
         "type": "protocol",

--- a/benchmarks/vad/runner.py
+++ b/benchmarks/vad/runner.py
@@ -54,7 +54,7 @@ DEFAULT_MODE_ENGINES = {
     "en": ["parakeet", "whispers2t_large_v3"],
 }
 
-DEFAULT_MODE_VADS = ["silero", "webrtc_mode3"]
+DEFAULT_MODE_VADS = ["silero", "webrtc"]
 
 
 @dataclass
@@ -109,8 +109,7 @@ class VADBenchmarkConfig:
         """Get VADs to benchmark.
 
         When param_source is "preset", only returns VADs that have optimized
-        presets (silero, tenvad, webrtc). Mode variants like webrtc_mode0 are
-        not used because the preset specifies the optimal mode.
+        presets (silero, tenvad, webrtc).
 
         Returns:
             List of VAD IDs

--- a/tests/benchmark_tests/vad/test_preset_integration.py
+++ b/tests/benchmark_tests/vad/test_preset_integration.py
@@ -36,12 +36,6 @@ class TestGetPresetVadIds:
         assert "javad_balanced" not in result
         assert "javad_precise" not in result
 
-    def test_excludes_mode_variants(self):
-        """Should not contain WebRTC mode variants."""
-        result = get_preset_vad_ids()
-        assert "webrtc_mode0" not in result
-        assert "webrtc_mode1" not in result
-
 
 class TestIsPresetAvailable:
     """Test is_preset_available function."""

--- a/tests/benchmark_tests/vad/test_runner.py
+++ b/tests/benchmark_tests/vad/test_runner.py
@@ -37,7 +37,7 @@ class TestVADBenchmarkConfig:
             mode="standard",
             languages=["ja"],
             engines=["parakeet_ja"],
-            vads=["silero", "webrtc_mode3"],
+            vads=["silero", "webrtc"],
             runs=3,
             device="cpu",
             output_dir=Path("/tmp/results"),
@@ -45,7 +45,7 @@ class TestVADBenchmarkConfig:
         assert config.mode == "standard"
         assert config.languages == ["ja"]
         assert config.engines == ["parakeet_ja"]
-        assert config.vads == ["silero", "webrtc_mode3"]
+        assert config.vads == ["silero", "webrtc"]
         assert config.runs == 3
         assert config.device == "cpu"
         assert config.output_dir == Path("/tmp/results")
@@ -493,7 +493,7 @@ class TestVADBenchmarkRunner:
             output_dir=tmp_path,
             languages=["ja"],
             engines=["failing_engine"],
-            vads=["silero", "webrtc_mode3"],
+            vads=["silero", "webrtc"],
         )
         runner = VADBenchmarkRunner(config)
 


### PR DESCRIPTION
## Summary

- Remove `webrtc_mode0`, `webrtc_mode1`, `webrtc_mode2`, `webrtc_mode3` entries from `VAD_REGISTRY`
- Keep only the base `webrtc` entry with `mode` as a parameter
- Simplify optimization objective by removing `_resolve_vad_id` method

## Rationale

1. **Mode is a parameter**: Like `threshold` or `hop_size`, `mode` should be treated as a tunable backend parameter
2. **Preset consistency**: `presets.py` already stores optimized `mode` per language via `backend_params`
3. **Registry simplification**: 5 entries → 1 entry
4. **Consistent API**:
   ```python
   # Default mode (0)
   create_vad("webrtc")
   
   # Custom mode via backend_params
   create_vad("webrtc", backend_params={"mode": 3})
   
   # Preset mode loads optimized value
   create_vad_with_preset("webrtc", "ja")  # mode=0 from optimization
   ```

## Changes

| File | Change |
|------|--------|
| `benchmarks/vad/factory.py` | Remove `webrtc_mode*` entries |
| `benchmarks/vad/runner.py` | Update `DEFAULT_MODE_VADS` |
| `benchmarks/vad/cli.py` | Update docstring examples |
| `benchmarks/optimization/objective.py` | Remove `_resolve_vad_id` method |
| `tests/*` | Update all `webrtc_mode*` references |

## Test Plan

- [x] Run `pytest tests/benchmark_tests/vad/` - 58 passed, 17 skipped
- [x] Run `pytest tests/benchmark_tests/optimization/` - 1 passed, 14 skipped
- [ ] CI validation

Related: #126 (Phase D VAD Optimization)
See: https://github.com/Mega-Gorilla/livecap-cli/issues/126#issuecomment-3591547835

🤖 Generated with [Claude Code](https://claude.com/claude-code)