### PR TITLE
ci: add paths-ignore to core-tests workflows

### DIFF
--- a/.github/workflows/core-tests-windows.yml
+++ b/.github/workflows/core-tests-windows.yml
@@ -4,8 +4,16 @@ on:
   workflow_dispatch:
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '.gitignore'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '.gitignore'
 
 jobs:
   tests:

--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -4,7 +4,15 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '.gitignore'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '.gitignore'
   workflow_dispatch:
 
 jobs:

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -171,16 +171,14 @@ LIVECAP_ENABLE_REALTIME_E2E=1 uv run python -m pytest tests/integration/realtime
 
 各ワークフローの実行条件は以下の通りです。
 
-| ワークフロー | push (main) | PR | スケジュール | 手動 | paths フィルタ |
+| ワークフロー | push (main) | PR | スケジュール | 手動 | paths-ignore |
 | --- | :---: | :---: | :---: | :---: | --- |
-| `core-tests.yml` | ✅ | ✅ | - | ✅ | なし（全変更で実行） |
-| `core-tests-windows.yml` | ✅ | ✅ | - | ✅ | なし（全変更で実行） |
+| `core-tests.yml` | ✅ | ✅ | - | ✅ | `docs/**`, `*.md`, `.gitignore` |
+| `core-tests-windows.yml` | ✅ | ✅ | - | ✅ | `docs/**`, `*.md`, `.gitignore` |
 | `integration-tests.yml` | - | ✅ | 週次（月曜 03:00 UTC） | ✅ | `engines/**`, `livecap_core/**`, `tests/integration/**`, `pyproject.toml`, `uv.lock` |
 | `benchmark-asr.yml` | - | - | - | ✅ | - |
 | `benchmark-vad.yml` | - | - | - | ✅ | - |
 | `verify-self-hosted-*.yml` | - | - | - | ✅ | - |
-
-> **Note**: `docs/**` や `*.md` の変更のみの場合、`core-tests*.yml` が実行されます。ドキュメントのみの変更でテストをスキップしたい場合は、今後 `paths-ignore` の追加を検討してください。
 
 ## CI 対応表
 


### PR DESCRIPTION
## Summary

Phase D of Issue #147: Add `paths-ignore` to core-tests workflows to skip tests for docs-only changes.

### Changes

- **`.github/workflows/core-tests.yml`**: Add `paths-ignore` for `docs/**`, `*.md`, `.gitignore`
- **`.github/workflows/core-tests-windows.yml`**: Add `paths-ignore` (same patterns)
- **`docs/testing/README.md`**: Update workflow trigger table to reflect new behavior

### Benefit

- Saves CI resources by skipping tests when only documentation is changed
- Reduces unnecessary workflow runs

### Test

This PR itself demonstrates the behavior:
- Since it modifies workflow files and docs, tests should still run
- Future docs-only PRs will skip `core-tests.yml` and `core-tests-windows.yml`

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)