### PR TITLE
docs: fix broken link in vad-optimization.md

### DIFF
--- a/docs/guides/vad-optimization.md
+++ b/docs/guides/vad-optimization.md
@@ -409,7 +409,7 @@ uv pip install torchaudio==2.9.1+cu126 --index-url https://download.pytorch.org/
 ## 関連ドキュメント
 
 - [VAD バックエンド比較](../reference/vad-comparison.md)
-- [VAD 最適化計画](../planning/vad-optimization-plan.md)
+- [VAD 最適化計画](../planning/archive/vad-optimization-plan.md)
 - [Optuna 公式ドキュメント](https://optuna.readthedocs.io/)
 
 ---


### PR DESCRIPTION
## Summary

- Fix broken link to `vad-optimization-plan.md` (correct path: `../planning/archive/vad-optimization-plan.md`)

## Changes

| File | Change |
|------|--------|
| `docs/guides/vad-optimization.md` | Update link path from `../planning/vad-optimization-plan.md` to `../planning/archive/vad-optimization-plan.md` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)