### PR TITLE
fix(engines): add missing batch_size param to WhisperS2T transcribe()

### DIFF
--- a/engines/whispers2t_engine.py
+++ b/engines/whispers2t_engine.py
@@ -306,7 +306,8 @@ class WhisperS2TEngine(BaseEngine):
                         [tmp_path],
                         lang_codes=[whisper_language],
                         tasks=["transcribe"],
-                        initial_prompts=[None]
+                        initial_prompts=[None],
+                        batch_size=self.batch_size
                     )
 
                 if self._enable_profiling:


### PR DESCRIPTION
## Summary
- Fix missing `batch_size` parameter in `WhisperS2T.transcribe()` method when `use_vad=False`

## Problem
When `use_vad=False`, the `batch_size` parameter was not being passed to `model.transcribe()`, causing the library to use its default value instead of the user-configured value.

## Changes
- `engines/whispers2t_engine.py:305-310`: Added `batch_size=self.batch_size` to the `transcribe()` call

## Verification
- Reviewed [official WhisperS2T docs](https://github.com/shashikg/WhisperS2T/blob/main/docs.md)
- Confirmed `batch_size` is a valid parameter for both `transcribe_with_vad()` and `transcribe()` methods
- All tests pass

## Test plan
- [x] `uv run pytest tests/core/engines/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)