### PR TITLE
fix(engines): correct language count to 100 and add validation tests

### DIFF
--- a/livecap_core/engines/whispers2t_engine.py
+++ b/livecap_core/engines/whispers2t_engine.py
@@ -91,7 +91,7 @@ class WhisperS2TEngine(BaseEngine):
         if asr_language not in WHISPER_LANGUAGES_SET:
             raise ValueError(
                 f"Unsupported language: {language}. "
-                f"WhisperS2T supports 99 languages. See: https://github.com/openai/whisper"
+                f"WhisperS2T supports 100 languages. See: https://github.com/openai/whisper"
             )
 
         # engine_name を統一（旧: f'whispers2t_{model_size}'）
@@ -517,7 +517,7 @@ class WhisperS2TEngine(BaseEngine):
 
     def get_supported_languages(self) -> list:
         """サポートされる言語のリストを取得"""
-        # WhisperS2Tは99言語対応
+        # WhisperS2Tは100言語対応
         return list(WHISPER_LANGUAGES)
         
     def get_required_sample_rate(self) -> int:

--- a/tests/core/engines/test_engine_factory.py
+++ b/tests/core/engines/test_engine_factory.py
@@ -134,3 +134,53 @@ def test_get_engines_for_language():
 
     yue_engines = EngineFactory.get_engines_for_language("yue")
     assert "whispers2t" in yue_engines
+
+
+class TestWhisperS2TValidation:
+    """Test WhisperS2T engine parameter validation."""
+
+    def test_invalid_model_size_raises_valueerror(self):
+        """Test that invalid model_size raises ValueError."""
+        from livecap_core.engines.whispers2t_engine import WhisperS2TEngine
+
+        with pytest.raises(ValueError, match="Unsupported model_size"):
+            WhisperS2TEngine(device="cpu", model_size="invalid-model")
+
+    def test_invalid_compute_type_raises_valueerror(self):
+        """Test that invalid compute_type raises ValueError."""
+        from livecap_core.engines.whispers2t_engine import WhisperS2TEngine
+
+        with pytest.raises(ValueError, match="Unsupported compute_type"):
+            WhisperS2TEngine(device="cpu", compute_type="invalid-type")
+
+    def test_invalid_language_raises_valueerror(self):
+        """Test that invalid language raises ValueError."""
+        from livecap_core.engines.whispers2t_engine import WhisperS2TEngine
+
+        with pytest.raises(ValueError, match="Unsupported language"):
+            WhisperS2TEngine(device="cpu", language="invalid-lang")
+
+    def test_valid_model_sizes_accepted(self):
+        """Test that all documented model sizes are accepted."""
+        from livecap_core.engines.whispers2t_engine import VALID_MODEL_SIZES
+
+        expected_sizes = {
+            "tiny", "base", "small", "medium",
+            "large-v1", "large-v2", "large-v3",
+            "large-v3-turbo", "distil-large-v3",
+        }
+        assert VALID_MODEL_SIZES == expected_sizes
+
+    def test_valid_compute_types_accepted(self):
+        """Test that all documented compute types are accepted."""
+        from livecap_core.engines.whispers2t_engine import VALID_COMPUTE_TYPES
+
+        expected_types = {"auto", "int8", "int8_float16", "float16", "float32"}
+        assert VALID_COMPUTE_TYPES == expected_types
+
+    def test_language_count_is_100(self):
+        """Test that WhisperS2T supports exactly 100 languages."""
+        from livecap_core.engines.whisper_languages import WHISPER_LANGUAGES
+
+        assert len(WHISPER_LANGUAGES) == 100
+        assert "yue" in WHISPER_LANGUAGES  # Cantonese is the 100th language


### PR DESCRIPTION
## Summary

PR #169 (WhisperS2T統合) のレビュー中に発見された問題の修正と、テストカバレッジの改善。

### 🐛 Bug Fixes

- `whispers2t_engine.py` のエラーメッセージを "99 languages" から "100 languages" に修正
- `whispers2t_engine.py` のコメントを "99言語対応" から "100言語対応" に修正

### ✅ New Tests

`TestWhisperS2TValidation` クラスを追加（6テスト）:

| テスト | 内容 |
|--------|------|
| `test_invalid_model_size_raises_valueerror` | 無効な model_size で ValueError |
| `test_invalid_compute_type_raises_valueerror` | 無効な compute_type で ValueError |
| `test_invalid_language_raises_valueerror` | 無効な language で ValueError |
| `test_valid_model_sizes_accepted` | 9種類の model_size が正しく定義されている |
| `test_valid_compute_types_accepted` | 5種類の compute_type が正しく定義されている |
| `test_language_count_is_100` | 100言語（yue含む）がサポートされている |

### Test Results

```
tests/core/engines/test_engine_factory.py: 13 passed
```

## Related

- Follow-up to #169 (WhisperS2T engine consolidation)
- Addresses code review findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)