### PR TITLE
docs(planning): Issue #168 Phase 2 - Languages.get_engines_for_language() 廃止計画

### DIFF
--- a/docs/planning/issue-168-supported-engines-fix.md
+++ b/docs/planning/issue-168-supported-engines-fix.md
@@ -111,6 +111,13 @@ WhisperS2T: WHISPER_LANGUAGES_SET でチェック → エラー or 成功
 | BCP-47 → ISO 639-1 | **`to_iso639_1()`** | 標準規格名で変換先が明確 |
 | ISO 639-1 → BCP-47 | `to_bcp47()` | 将来実装時（RIVA等） |
 
+**ISO 639-3（3文字コード）の扱い**:
+- `to_iso639_1()` は langcodes の `language` サブタグを返す
+- ISO 639-1（2文字）が存在しない言語は ISO 639-3（3文字）を返す
+- 例: `yue`（粵語/Cantonese）、`haw`（ハワイ語）
+- Whisper は `yue` 等の3文字コードを明示的にサポート（`WHISPER_LANGUAGES` に含まれる）
+- **実装方針**: 3文字コードも許容。バリデーションは各エンジンの `supported_languages` で行う。
+
 **廃止した候補**:
 - `to_asr_code()`: 「ASR」は用途であり、変換形式ではない
 - `to_google_code()`: Google Translate は現在 ISO 639-1 を受け付けるため不要


### PR DESCRIPTION
## Summary
- Issue #168 Phase 2 の計画ドキュメントを整理・簡潔化
- Phase 1（asr_code 対応）は PR #171 で完了済み
- 本ドキュメントは `Languages.get_engines_for_language()` 廃止計画を記載

## 変更内容
- 完了した Phase 1 の詳細を削除
- Phase 2（廃止計画）に焦点を絞る
- ドキュメントを 279行 → 121行 に簡潔化

## Phase 2 計画概要
1. `Languages.get_engines_for_language()` に `@deprecated` 追加
2. `LanguageInfo.supported_engines` フィールド削除
3. `riva` デッドコード参照削除
4. ドキュメント更新

## 関連
- Closes: なし（計画ドキュメントのみ）
- 関連 Issue: #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)