### PR TITLE
fix(utils): simplify detect_device() to return str instead of Tuple

### DIFF
--- a/livecap_core/engines/canary_engine.py
+++ b/livecap_core/engines/canary_engine.py
@@ -90,7 +90,7 @@ class CanaryEngine(BaseEngine):
         self._initialized = False
 
         # デバイスの自動検出と設定（共通関数を使用）
-        self.torch_device, _ = detect_device(device, "Canary")
+        self.torch_device = detect_device(device, "Canary")
 
         # ライブラリ事前ロードを開始
         LibraryPreloader.start_preloading('canary')

--- a/livecap_core/engines/parakeet_engine.py
+++ b/livecap_core/engines/parakeet_engine.py
@@ -119,7 +119,7 @@ class ParakeetEngine(BaseEngine):
         self.model = None
 
         # デバイスの自動検出と設定（共通関数を使用）
-        self.torch_device, _ = detect_device(device, "Parakeet")
+        self.torch_device = detect_device(device, "Parakeet")
         
     def _check_dependencies(self) -> None:
         """

--- a/livecap_core/engines/voxtral_engine.py
+++ b/livecap_core/engines/voxtral_engine.py
@@ -90,7 +90,7 @@ class VoxtralEngine(BaseEngine):
         self.processor = None
 
         # デバイスの自動検出と設定（共通関数を使用）
-        self.torch_device, self.device_str = detect_device(device, "Voxtral")
+        self.torch_device = detect_device(device, "Voxtral")
 
         # GPU RAM警告
         if self.torch_device == "cuda":

--- a/livecap_core/engines/whispers2t_engine.py
+++ b/livecap_core/engines/whispers2t_engine.py
@@ -106,10 +106,7 @@ class WhisperS2TEngine(BaseEngine):
         os.environ['CUDNN_BENCHMARK'] = '0'
 
         # デバイスの自動検出と設定（共通関数を使用）
-        # detect_device() は Tuple[str, str] を返すため、最初の要素のみ使用
-        # 注: #166 完了後は戻り値が str になる
-        device_result = detect_device(device, "WhisperS2T")
-        self.device = device_result[0] if isinstance(device_result, tuple) else device_result
+        self.device = detect_device(device, "WhisperS2T")
 
         # compute_type の解決（autoの場合はデバイスに応じて最適化）
         self.compute_type = self._resolve_compute_type(compute_type)


### PR DESCRIPTION
## Summary

- `detect_device()` の戻り値を `Tuple[str, str]` から `str` に変更
- 全エンジンで使用されていなかった `compute_type` の返却を削除
- Voxtral から未使用の `device_str` 変数を削除
- CPU 明示指定時のログメッセージを追加

## Background

調査により、`detect_device()` の2番目の戻り値（`compute_type`）が全てのエンジンで未使用であることを確認：

| Engine | Usage | 2nd value |
|--------|-------|-----------|
| WhisperS2T | `device_result[0]` only | Ignored (has own `_resolve_compute_type()`) |
| Parakeet | `self.torch_device, _ = ...` | Discarded |
| Canary | `self.torch_device, _ = ...` | Discarded |
| Voxtral | `self.torch_device, self.device_str = ...` | Stored but never used |

## Changes

### `livecap_core/utils/__init__.py`
- Return type: `Tuple[str, str]` → `str`
- Only returns device string ("cuda" or "cpu")
- Added explicit log for CPU-requested case

### Engine files
- `whispers2t_engine.py`: Removed tuple handling workaround
- `parakeet_engine.py`: Removed tuple unpacking
- `canary_engine.py`: Removed tuple unpacking
- `voxtral_engine.py`: Removed tuple unpacking and unused `device_str`

## Test plan

- [x] `pytest tests/core/engines/test_engine_factory.py` - 20 tests passed
- [x] `pytest tests/core` - 48/49 passed (1 unrelated failure about NeMo extras)

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)