### PR TITLE
docs: remove outdated --extra vad references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,10 @@ livecap-core is a high-performance speech transcription library providing real-t
 
 ```bash
 # Environment setup (uv preferred)
-uv sync --extra vad --extra engines-torch --extra dev
+uv sync --extra engines-torch --extra dev
 
 # Without uv
-pip install -e ".[vad,engines-torch,dev]"
+pip install -e ".[engines-torch,dev]"
 
 # Run tests
 uv run pytest tests                           # Full suite

--- a/docs/guides/benchmark/asr-benchmark.md
+++ b/docs/guides/benchmark/asr-benchmark.md
@@ -258,12 +258,12 @@ torch.cuda.OutOfMemoryError: CUDA out of memory
 #### エンジンのロードエラー
 
 ```
-ImportError: silero_vad is required
+ImportError: No module named 'torch'
 ```
 
 **解決策**: 必要な依存関係をインストール
 ```bash
-uv sync --extra vad --extra engines-torch --extra engines-nemo
+uv sync --extra engines-torch --extra engines-nemo
 ```
 
 ### 環境変数

--- a/docs/guides/benchmark/vad-benchmark.md
+++ b/docs/guides/benchmark/vad-benchmark.md
@@ -6,7 +6,7 @@ VAD（Voice Activity Detection）+ ASRパイプラインの精度・性能を評
 
 ```bash
 # 依存関係のインストール
-uv sync --extra benchmark --extra vad --extra engines-torch
+uv sync --extra benchmark --extra engines-torch
 
 # クイックベンチマーク実行
 uv run python -m benchmarks.vad --mode quick
@@ -231,17 +231,6 @@ VAD 'javad_balanced' has no optimized preset.
 ```
 
 **解決策**: preset モードでは silero, tenvad, webrtc のみ使用可能。JaVADは `--param-source default` で使用してください。
-
-#### VAD依存関係が不足
-
-```
-ImportError: silero_vad is required
-```
-
-**解決策**: VAD依存関係をインストール
-```bash
-uv sync --extra vad
-```
 
 #### TenVADのONNX警告
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,11 +7,11 @@ livecap-core の使用例を示すサンプルスクリプト集です。
 ### インストール
 
 ```bash
-# 基本インストール（VAD + PyTorch エンジン）
-pip install livecap-core[vad,engines-torch]
+# 基本インストール（PyTorch エンジン）
+pip install livecap-core[engines-torch]
 
 # または uv を使用
-uv sync --extra vad --extra engines-torch
+uv sync --extra engines-torch
 ```
 
 ### テスト用音声ファイル
@@ -67,14 +67,6 @@ LIVECAP_LANGUAGE=en python examples/realtime/basic_file_transcription.py tests/a
 ```
 
 ## トラブルシューティング
-
-### Q: `ModuleNotFoundError: No module named 'silero_vad'`
-
-VAD 依存がインストールされていません：
-
-```bash
-pip install livecap-core[vad]
-```
 
 ### Q: `OSError: PortAudio library not found`
 


### PR DESCRIPTION
## Summary

VAD はデフォルト依存関係に統合されたため、`[vad]` extra は存在しません。ドキュメント内の古い `--extra vad` 記述を削除します。

## Changes

### CLAUDE.md
- `uv sync --extra vad --extra engines-torch --extra dev` → `uv sync --extra engines-torch --extra dev`
- `pip install -e ".[vad,engines-torch,dev]"` → `pip install -e ".[engines-torch,dev]"`

### examples/README.md
- インストールコマンドから `--extra vad` を削除
- 発生しなくなった `silero_vad` のトラブルシューティングセクションを削除

### docs/guides/benchmark/asr-benchmark.md
- `--extra vad` を削除
- エラー例を `silero_vad` から `torch` に変更（より一般的なケース）

### docs/guides/benchmark/vad-benchmark.md
- クイックスタートから `--extra vad` を削除
- 発生しなくなった VAD 依存関係トラブルシューティングセクションを削除

## Statistics
- 4 files changed
- +8 lines, -27 lines (net: -19 lines)

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)