### PR TITLE
docs(planning): Issue #74 実装計画 - CLI・パッケージ名変更

### DIFF
--- a/docs/planning/issue-74/README.md
+++ b/docs/planning/issue-74/README.md
@@ -118,9 +118,13 @@ livecap-core --as-json        # JSON出力
 > PyPI 公開前は `.[translation]` のようなローカル参照形式でテストすること。
 > 実装時に循環依存や意図しない PyPI 参照が起きないか検証が必要。
 
+> **Phase 6B との連携:** Phase 6B で `name = "livecap-cli"` に変更するため、
+> 自己参照も `livecap-cli[...]` に更新する必要がある。Phase 6A と 6B を
+> 同一 PR で行うか、6A では自己参照を避けて依存を直接列挙することを推奨。
+
 **完了条件:**
-- [ ] `pip install livecap-core[recommended]` が動作
-- [ ] `pip install livecap-core[all]` が動作
+- [ ] `pip install livecap-core[recommended]` が動作 (または 6B と同時なら `livecap-cli[recommended]`)
+- [ ] `pip install livecap-core[all]` が動作 (または 6B と同時なら `livecap-cli[all]`)
 - [ ] 既存の extras が引き続き動作
 
 ### Phase 6B: CLI コマンド実装 + エントリポイント変更 (中リスク)
@@ -228,9 +232,14 @@ livecap-cli transcribe input.mp4 -o output.srt \
 > **デバイス表記について:** CLI では `gpu` を使用し、内部で `cuda` にマッピングする。
 > これは Issue #74 の仕様 (`auto/gpu/cpu`) に準拠し、ユーザーフレンドリーな表記を優先する。
 
+> **モデルサイズについて:** CLI のデフォルトは `base` だが、エンジン API のデフォルトは
+> `large-v3` (`livecap_core/engines/metadata.py:147`)。CLI では起動速度とリソース効率を
+> 優先し、ユーザーが明示的に `--model-size large-v3` を指定した場合のみ高精度モードを使用する。
+
 > **VAD バックエンド選択について:** VAD バックエンド選択は既に API レベルで実装済み
 > (`VADProcessor.from_language()`)。CLI では `--vad auto` がデフォルトで、
-> `--language` に基づき最適な VAD を自動選択する。
+> `--language` に基づき最適な VAD を自動選択する。未対応言語の場合は警告を表示し、
+> Silero VAD にフォールバックする（`VADProcessor()` のデフォルト動作）。
 
 **完了条件:**
 - [ ] `livecap-cli info` が動作


### PR DESCRIPTION
## 概要

Issue #74 (Phase 6: 依存関係整理・CLI・パッケージ名変更) の実装計画ドキュメントを追加します。

Refs #74

## 計画概要

### Phase 6A: pyproject.toml 整理 (低リスク)
- `recommended` / `all` メタエクストラの追加
- 既存の extras 構造を維持

### Phase 6B: CLI コマンド実装 + エントリポイント変更 (中リスク)

> **Note:** 当初 Phase 6C で予定していたパッケージ名変更を Phase 6B に統合。
> 新しいサブコマンド CLI を古い `livecap-core` で実装してからすぐに `livecap-cli` に
> 変更するのは二度手間であり、最初から `livecap-cli` として提供する方が効率的。

| コマンド | 説明 |
|---------|------|
| `livecap-cli info` | 診断情報 |
| `livecap-cli devices` | オーディオデバイス一覧 |
| `livecap-cli engines` | ASRエンジン一覧 |
| `livecap-cli translators` | 翻訳器一覧 |
| `livecap-cli transcribe --realtime --mic <id>` | マイク入力リアルタイム |
| `livecap-cli transcribe <file> -o <output>` | ファイル文字起こし |

**主なオプション:**
- `--engine` - ASRエンジン選択
- `--device auto/gpu/cpu` - デバイス選択 (内部で `cuda` にマッピング)
- `--vad auto/silero/tenvad/webrtc` - VADバックエンド選択 (既存API活用)
- `--translate` - 翻訳器選択

## 互換性方針

Epic #64 の方針「互換性維持は不要」に従い:
- ❌ 旧フラグ (`--info`, `--ensure-ffmpeg`, `--as-json`) は完全廃止
- ❌ 旧エントリポイント (`livecap-core`) は完全廃止
- ✅ Python API (`from livecap_core import ...`) は維持

## スコープ外 (将来課題)

- `--system` (システム音声キャプチャ) - プラットフォーム依存性が高い
  - Issue #74 本文には要件として記載されているが、Phase 6 ではスコープ外
  - 必要に応じてフォローアップ Issue を作成

## 現状分析

**既存の活用可能なコンポーネント:**
- `examples/realtime/async_microphone.py` → transcribe --mic のロジック
- `FileTranscriptionPipeline` → transcribe <file> の処理
- `EngineMetadata.get_all()` → engines コマンド
- `TranslatorMetadata.get_all()` → translators コマンド
- `MicrophoneSource.list_devices()` → devices コマンド
- `VADProcessor.from_language()` → --vad auto の実装

## 実装順序

```
Phase 6A (pyproject.toml整理)           → PR #1
    ↓
Phase 6B (CLI実装 + エントリポイント変更)  → PR #2
```

## 変更ファイル

- `docs/planning/issue-74/README.md` - 新規 (347行)

🤖 Generated with [Claude Code](https://claude.com/claude-code)