### PR TITLE
fix(deps): add version constraints for whisper-s2t indirect dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
   "tokenizers>=0.14.0",  # Python 3.10+ wheels required; pip resolver fix for whisper-s2t
   "optimum>=1.17.0",  # Proper metadata/wheels; pip resolver fix for whisper-s2t transitive dep
   "transformers>=4.36.0",  # Compatible with tokenizers>=0.14.0; pip resolver fix for whisper-s2t
+  "ctranslate2>=3.24.0",  # Python 3.10+ wheels; pip resolver fix for whisper-s2t transitive dep
   "tqdm>=4.65",
   "whisper-s2t",
   # VAD backends (required for realtime transcription)

--- a/uv.lock
+++ b/uv.lock
@@ -1738,6 +1738,7 @@ version = "1.0.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },
+    { name = "ctranslate2" },
     { name = "ffmpeg-python" },
     { name = "huggingface-hub" },
     { name = "langcodes" },
@@ -1746,6 +1747,7 @@ dependencies = [
     { name = "numba" },
     { name = "numpy" },
     { name = "onnxruntime" },
+    { name = "optimum" },
     { name = "pydub" },
     { name = "requests" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1757,6 +1759,7 @@ dependencies = [
     { name = "ten-vad" },
     { name = "tokenizers" },
     { name = "tqdm" },
+    { name = "transformers" },
     { name = "webrtcvad" },
     { name = "whisper-s2t" },
 ]
@@ -1833,6 +1836,7 @@ requires-dist = [
     { name = "accelerate", marker = "extra == 'all'", specifier = ">=0.20.0" },
     { name = "accelerate", marker = "extra == 'translation-riva'", specifier = ">=0.20.0" },
     { name = "appdirs", specifier = ">=1.4.4" },
+    { name = "ctranslate2", specifier = ">=3.24.0" },
     { name = "ctranslate2", marker = "extra == 'all'", specifier = ">=4.0.0" },
     { name = "ctranslate2", marker = "extra == 'translation-local'", specifier = ">=4.0.0" },
     { name = "cython", marker = "extra == 'all'" },
@@ -1866,6 +1870,7 @@ requires-dist = [
     { name = "numba", specifier = ">=0.55.0" },
     { name = "numpy" },
     { name = "onnxruntime" },
+    { name = "optimum", specifier = ">=1.17.0" },
     { name = "optuna", marker = "extra == 'all'", specifier = ">=3.0" },
     { name = "optuna", marker = "extra == 'optimization'", specifier = ">=3.0" },
     { name = "plotly", marker = "extra == 'all'", specifier = ">=5.0" },
@@ -1892,6 +1897,7 @@ requires-dist = [
     { name = "torchvision", marker = "extra == 'all'" },
     { name = "torchvision", marker = "extra == 'engines-torch'" },
     { name = "tqdm", specifier = ">=4.65" },
+    { name = "transformers", specifier = ">=4.36.0" },
     { name = "transformers", marker = "extra == 'all'", specifier = ">=4.57.0" },
     { name = "transformers", marker = "extra == 'engines-nemo'", specifier = ">=4.57.0" },
     { name = "transformers", marker = "extra == 'translation-local'", specifier = ">=4.40.0" },


### PR DESCRIPTION
## Summary

- Add `optimum>=1.17.0` constraint to prevent pip from resolving ancient versions without metadata
- Add `transformers>=4.36.0` constraint for compatibility with tokenizers>=0.14.0

## Background

When installing with pip (vs uv), the resolver can select old package versions that:
- Lack `requires_python` metadata (pip doesn't know they're incompatible)
- Have no pre-built wheels (requires Rust/C++ build from source)
- Fail to build due to missing files or API changes

These packages are indirect dependencies of whisper-s2t which has no version constraints on PyPI.

## Test plan

- [ ] `pip install -e ".[engines-torch]"` in clean Python 3.10+ environment succeeds without build errors

Fixes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)