### PR TITLE
fix: replace webrtcvad with webrtcvad-wheels for cross-platform compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
   # VAD backends (required for realtime transcription)
   # NOTE: TenVAD requires libc++ on Linux: sudo apt-get install libc++1
   "silero-vad>=5.1",
-  "webrtcvad>=2.0.10",
+  "webrtcvad-wheels>=2.0.10",  # Pre-built wheels for Windows/macOS/Linux (no C compiler required)
   "ten-vad @ git+https://github.com/TEN-framework/ten-vad.git@a64b408d9ff89cd92bd0772ed99f9d58b7a005b1",
 ]
 keywords = ["speech-to-text", "translation", "live captioning"]


### PR DESCRIPTION
## Summary

- Replace `webrtcvad` with `webrtcvad-wheels` in dependencies
- Enables installation on Windows without Visual Studio Build Tools
- Pre-built binary wheels available for Windows/macOS/Linux

## Problem

`webrtcvad` requires compiling C extensions from source, which fails on Windows without Visual Studio Build Tools installed:

```
error: Unable to find a compatible Visual Studio installation.
```

## Solution

`webrtcvad-wheels` is a fork that provides pre-built binary wheels:
- Same API (`import webrtcvad` works identically)
- Supports Python 3.6-3.13
- Includes bug fix for out-of-bounds memory read
- ~179,000 weekly downloads on PyPI

## References

- [webrtcvad-wheels PyPI](https://pypi.org/project/webrtcvad-wheels/)
- [webrtcvad-wheels GitHub](https://github.com/daanzu/py-webrtcvad-wheels)

## Test plan

- [ ] Verify `pip install livecap-cli` works on Windows without Visual Studio
- [ ] Verify `import webrtcvad` works correctly
- [ ] Run existing VAD tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)