### PR TITLE
fix(engines): use correct qwen-asr class name Qwen3ASRModel

### DIFF
--- a/livecap_cli/engines/qwen3asr_engine.py
+++ b/livecap_cli/engines/qwen3asr_engine.py
@@ -62,7 +62,7 @@ def check_qwen_asr_availability() -> bool:
 
     # 通常環境では実際にインポートを試行
     try:
-        from qwen_asr import Qwen3ASR
+        from qwen_asr import Qwen3ASRModel as Qwen3ASR
         QWEN_ASR_AVAILABLE = True
         logger.info("qwen-asr が正常にインポートされました")
     except ImportError as e:
@@ -229,7 +229,7 @@ class Qwen3ASREngine(BaseEngine):
         prepare_qwen_asr_environment()
 
         # qwen-asr モジュールをインポート
-        from qwen_asr import Qwen3ASR
+        from qwen_asr import Qwen3ASRModel as Qwen3ASR
 
         self.report_progress(80, "Initializing Qwen3-ASR model...")
 


### PR DESCRIPTION
## Summary

- Fix ImportError when loading Qwen3-ASR engine
- qwen-asr 0.0.6 exports `Qwen3ASRModel`, not `Qwen3ASR`

## Changes

| File | Change |
|------|--------|
| `livecap_cli/engines/qwen3asr_engine.py` | Change `from qwen_asr import Qwen3ASR` to `from qwen_asr import Qwen3ASRModel as Qwen3ASR` (2 locations) |

## Test plan

- [x] All 20 unit tests pass (`pytest tests/core/engines/test_qwen3asr_engine.py`)

Fixes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)