### PR TITLE
fix(engines): use from_pretrained API for Qwen3-ASR model loading

### DIFF
--- a/livecap_cli/engines/qwen3asr_engine.py
+++ b/livecap_cli/engines/qwen3asr_engine.py
@@ -239,9 +239,12 @@ class Qwen3ASREngine(BaseEngine):
         with unicode_safe_download_directory():
             with manager.huggingface_cache() as hf_cache:
                 # モデルをロード（from_pretrained API を使用）
+                # device_map: "cpu" はそのまま、"cuda" は "auto" に変換
+                # "auto" は利用可能な GPU を自動選択する
+                device_map = "auto" if self.torch_device == "cuda" else self.torch_device
                 model = Qwen3ASR.from_pretrained(
                     self.model_name,
-                    device_map=self.torch_device,
+                    device_map=device_map,
                 )
 
         self.report_progress(85, "Model loaded successfully")


### PR DESCRIPTION
## Summary

- Fix Qwen3-ASR model loading API compatibility
- qwen-asr 0.0.6 changed the initialization pattern

## Problem

```
TypeError: Qwen3ASRModel.__init__() got an unexpected keyword argument 'model_path'
```

## Solution

Use `from_pretrained()` class method instead of direct constructor:

```python
# Old (broken)
model = Qwen3ASRModel(model_path=..., device=...)

# New (working)
model = Qwen3ASRModel.from_pretrained(model_name, device_map=...)
```

## Test plan

- [x] Model loads successfully
- [x] Transcription works
- [x] Unit tests pass

Fixes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)