### PR TITLE
fix(benchmark): skip non-preset VADs with warning instead of erroring

### DIFF
--- a/benchmarks/vad/cli.py
+++ b/benchmarks/vad/cli.py
@@ -169,9 +169,15 @@ def main(args: list[str] | None = None) -> int:
     # Validate VAD names based on param_source
     param_source = getattr(parsed, 'param_source', 'default')
     if param_source == "preset":
-        # Preset mode: filter out VADs that lack optimized presets (with warning)
+        # Preset mode: reject unknown VADs (typo), skip known but non-preset VADs
+        all_vads = set(get_all_vad_ids())
         preset_vads = set(get_preset_vad_ids())
         if parsed.vad:
+            for vad_id in parsed.vad:
+                if vad_id not in all_vads:
+                    logger.error(f"Unknown VAD: {vad_id}")
+                    logger.error(f"Available VADs: {', '.join(sorted(all_vads))}")
+                    return 1
             skipped = [v for v in parsed.vad if v not in preset_vads]
             kept = [v for v in parsed.vad if v in preset_vads]
             for vad_id in skipped:

--- a/benchmarks/vad/preset_integration.py
+++ b/benchmarks/vad/preset_integration.py
@@ -94,7 +94,7 @@ def create_vad_with_preset(
 ) -> VADBenchmarkBackend:
     """Create a VAD backend with optimized preset parameters.
 
-    Loads the Bayesian-optimized parameters from livecap_cli/vad/presets.py
+    Loads the Bayesian-optimized parameters from livecap_cli/vad/presets/
     and creates a VAD backend configured with those parameters.
 
     Args:

--- a/benchmarks/vad/runner.py
+++ b/benchmarks/vad/runner.py
@@ -75,7 +75,7 @@ class VADBenchmarkConfig:
 
     # Parameter source: "default" or "preset"
     # - "default": Use hardcoded default parameters from factory.py
-    # - "preset": Load optimized parameters from livecap_cli/vad/presets.py
+    # - "preset": Load optimized parameters from livecap_cli/vad/presets/
     param_source: str = "default"
 
     # Number of runs per file for RTF measurement

--- a/tests/benchmark_tests/vad/test_cli.py
+++ b/tests/benchmark_tests/vad/test_cli.py
@@ -78,6 +78,17 @@ class TestPresetVADFiltering:
         assert kept == ["silero", "tenvad", "webrtc"]
 
 
+    def test_preset_unknown_vad_returns_error(self, caplog):
+        """Unknown VAD (typo) should error even in preset mode."""
+        with caplog.at_level(logging.ERROR):
+            exit_code = main([
+                "--param-source", "preset",
+                "--vad", "sileroo",
+            ])
+        assert exit_code == 1
+        assert "Unknown VAD" in caplog.text
+
+
 class TestDefaultModeVADValidation:
     """Test VAD validation in default (non-preset) mode."""
 


### PR DESCRIPTION
## Summary

- `--param-source preset` で非プリセット VAD（javad 系）が含まれている場合、エラー終了ではなく警告してスキップするように変更
- CI で `vad_preset=all` + `param_source=preset` の組み合わせが動作するようになる
- ヘルプテキストの `presets.py` 参照を `presets/` に更新

## 背景

#232 Phase 1 検証ベンチマーク実行時に発覚:
- `vad_preset=all` は javad 系を含む全 VAD に展開される
- `param_source=preset` と組み合わせると、javad 系に最適化プリセットがないためエラー終了していた

## 変更内容

### `benchmarks/vad/cli.py`
- 非プリセット VAD を `WARNING` ログで通知しスキップ
- 全 VAD がスキップされた場合のみエラー終了（安全弁）
- ヘルプ文の参照パスを更新

### `tests/benchmark_tests/vad/test_cli.py` (新規)
- CLI 引数パース、プリセットフィルタリング、エラーケースのテスト（7件）

## Test plan

- [x] `uv run pytest tests/benchmark_tests/vad/test_cli.py -v` — 7 passed
- [x] `uv run pytest tests/benchmark_tests/ -v` — 132 passed, 14 skipped
- [ ] CI で `vad_preset=all` + `param_source=preset` が警告付きで動作すること

## 関連

- #232 — VAD 最適化パイプライン自動化
- `8da6c36` — quick モードのデータ準備マッピング修正（main に直接コミット済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)