### PR TITLE
fix(ci): add qwen3asr to benchmark CI and preserve results on partial failure

### DIFF
--- a/.github/workflows/benchmark-vad.yml
+++ b/.github/workflows/benchmark-vad.yml
@@ -154,7 +154,7 @@ jobs:
 
           # 3. Install project dependencies
           Write-Host "Installing project dependencies..."
-          uv pip install -e ".[engines-torch,engines-nemo,benchmark,dev]"
+          uv pip install -e ".[engines-torch,engines-nemo,engines-qwen3asr,benchmark,dev]"
 
           # 4. Remove conflicting cuDNN package (may cause issues)
           Write-Host "Removing conflicting cuDNN package..."
@@ -322,6 +322,7 @@ jobs:
           }
 
       - name: Upload benchmark results
+        if: always() && steps.benchmark.outputs.output_dir != ''
         uses: actions/upload-artifact@v4
         with:
           name: vad-benchmark-results-${{ steps.benchmark.outputs.output_name }}
@@ -329,6 +330,7 @@ jobs:
           retention-days: 90
 
       - name: Post summary to GitHub
+        if: always() && steps.benchmark.outputs.output_dir != ''
         shell: pwsh
         run: |
           $summaryPath = "${{ steps.benchmark.outputs.output_dir }}\summary.md"


### PR DESCRIPTION
## Summary

- benchmark-vad.yml に `engines-qwen3asr` extra を追加し、Qwen3-ASR ベンチマークを実行可能にする
- Upload/Summary ステップに `if: always()` を追加し、部分失敗時の結果消失を防止する

## 問題の詳細

### 発生した事象

ベースライン計測（#232）の `workflow_dispatch` 実行で、JA ラン（[Run 21702735189](https://github.com/Mega-Gorilla/livecap-cli/actions/runs/21702735189)）が failure になった。

### 根本原因

**1. `qwen3asr` エンジン未インストール**

`benchmark-vad.yml` のインストールコマンドに `engines-qwen3asr` extra が含まれていなかった:

```
# Before
uv pip install -e ".[engines-torch,engines-nemo,benchmark,dev]"
```

`workflow_dispatch` で `engines: parakeet_ja,reazonspeech,whispers2t,qwen3asr` を指定したが、`qwen-asr` パッケージが未インストールのため `qwen3asr` の3組み合わせすべてが失敗:

```
[ERROR] qwen-asr is not installed. Please run: pip install 'livecap-cli[engines-qwen3asr]'
```

**2. 結果アーティファクトの消失**

`Upload benchmark results` と `Post summary to GitHub` ステップに `if: always()` が付いていなかったため、ベンチマーク CLI が exit code 1 を返すとこれらのステップがスキップされた。

結果、**成功した9/12組み合わせのベンチマーク結果も消失**した。

### 影響

| 項目 | 詳細 |
|------|------|
| 失敗した組み合わせ | `qwen3asr+silero`, `qwen3asr+tenvad`, `qwen3asr+webrtc` |
| 成功した組み合わせ | 9/12（parakeet_ja, reazonspeech, whispers2t × 3 VAD） |
| 消失したデータ | 成功9件の結果 + summary.md |
| EN ラン ([21702737623](https://github.com/Mega-Gorilla/livecap-cli/actions/runs/21702737623)) | 同様の失敗が見込まれる |

## 修正内容

### 1. `engines-qwen3asr` の追加

```diff
- uv pip install -e ".[engines-torch,engines-nemo,benchmark,dev]"
+ uv pip install -e ".[engines-torch,engines-nemo,engines-qwen3asr,benchmark,dev]"
```

`qwen-asr>=0.0.6` のみの追加（`torch` は既にインストール済み）。

### 2. `if: always()` の追加

Upload と Summary ステップに `if: always() && steps.benchmark.outputs.output_dir != ''` を追加。`output_dir` の存在チェックにより、ベンチマーク自体が実行されなかった場合は不要な実行を回避する。

## Related

- #232 — ベースライン計測が本修正によりブロック解除される
- #221 — Qwen3-ASR エンジン統合

🤖 Generated with [Claude Code](https://claude.com/claude-code)