### PR TITLE
feat(vad): add whispers2t/voxtral EN presets and fix workflow detection

### DIFF
--- a/.github/workflows/optimize-vad.yml
+++ b/.github/workflows/optimize-vad.yml
@@ -246,8 +246,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Check for changes to preset files
-          $changed = git diff --name-only -- livecap_cli/vad/presets/
+          # Stage preset files first so new (untracked) files are detected
+          git add livecap_cli/vad/presets/*.json
+          $changed = git diff --cached --name-only -- livecap_cli/vad/presets/
           if (-not $changed) {
             Write-Host "No changes to preset files, skipping PR creation"
             exit 0

--- a/livecap_cli/vad/presets/silero_en_voxtral.json
+++ b/livecap_cli/vad/presets/silero_en_voxtral.json
@@ -1,0 +1,19 @@
+{
+  "vad_type": "silero",
+  "language": "en",
+  "vad_config": {
+    "threshold": 0.20583720509507172,
+    "neg_threshold": 0.12440801750092566,
+    "min_speech_ms": 150,
+    "min_silence_ms": 240,
+    "speech_pad_ms": 130
+  },
+  "backend": {},
+  "metadata": {
+    "score": 0.03325325541228107,
+    "metric": "wer",
+    "trials": 100,
+    "engine": "voxtral",
+    "created_at": "2026-02-23T19:07:59.364164"
+  }
+}

--- a/livecap_cli/vad/presets/silero_en_whispers2t.json
+++ b/livecap_cli/vad/presets/silero_en_whispers2t.json
@@ -1,0 +1,19 @@
+{
+  "vad_type": "silero",
+  "language": "en",
+  "vad_config": {
+    "threshold": 0.5806536307567319,
+    "neg_threshold": 0.4232339360327326,
+    "min_speech_ms": 300,
+    "min_silence_ms": 280,
+    "speech_pad_ms": 100
+  },
+  "backend": {},
+  "metadata": {
+    "score": 0.04192062059090661,
+    "metric": "wer",
+    "trials": 100,
+    "engine": "whispers2t",
+    "created_at": "2026-02-23T00:29:37.430638"
+  }
+}

--- a/livecap_cli/vad/presets/tenvad_en_voxtral.json
+++ b/livecap_cli/vad/presets/tenvad_en_voxtral.json
@@ -1,0 +1,21 @@
+{
+  "vad_type": "tenvad",
+  "language": "en",
+  "vad_config": {
+    "threshold": 0.7012569354876322,
+    "neg_threshold": 0.38549572688998907,
+    "min_speech_ms": 500,
+    "min_silence_ms": 230,
+    "speech_pad_ms": 150
+  },
+  "backend": {
+    "hop_size": 256
+  },
+  "metadata": {
+    "score": 0.04590226230718243,
+    "metric": "wer",
+    "trials": 100,
+    "engine": "voxtral",
+    "created_at": "2026-02-25T01:39:16.811967"
+  }
+}

--- a/livecap_cli/vad/presets/tenvad_en_whispers2t.json
+++ b/livecap_cli/vad/presets/tenvad_en_whispers2t.json
@@ -1,0 +1,21 @@
+{
+  "vad_type": "tenvad",
+  "language": "en",
+  "vad_config": {
+    "threshold": 0.3809906454124316,
+    "neg_threshold": 0.32251378747070214,
+    "min_speech_ms": 450,
+    "min_silence_ms": 250,
+    "speech_pad_ms": 80
+  },
+  "backend": {
+    "hop_size": 256
+  },
+  "metadata": {
+    "score": 0.037712110884294436,
+    "metric": "wer",
+    "trials": 100,
+    "engine": "whispers2t",
+    "created_at": "2026-02-23T02:21:30.377503"
+  }
+}

--- a/livecap_cli/vad/presets/webrtc_en_voxtral.json
+++ b/livecap_cli/vad/presets/webrtc_en_voxtral.json
@@ -1,0 +1,20 @@
+{
+  "vad_type": "webrtc",
+  "language": "en",
+  "vad_config": {
+    "min_speech_ms": 500,
+    "min_silence_ms": 290,
+    "speech_pad_ms": 140
+  },
+  "backend": {
+    "mode": 0,
+    "frame_duration_ms": 30
+  },
+  "metadata": {
+    "score": 0.03663248246542117,
+    "metric": "wer",
+    "trials": 100,
+    "engine": "voxtral",
+    "created_at": "2026-02-24T15:34:33.769321"
+  }
+}

--- a/livecap_cli/vad/presets/webrtc_en_whispers2t.json
+++ b/livecap_cli/vad/presets/webrtc_en_whispers2t.json
@@ -1,0 +1,20 @@
+{
+  "vad_type": "webrtc",
+  "language": "en",
+  "vad_config": {
+    "min_speech_ms": 400,
+    "min_silence_ms": 280,
+    "speech_pad_ms": 80
+  },
+  "backend": {
+    "mode": 1,
+    "frame_duration_ms": 30
+  },
+  "metadata": {
+    "score": 0.037712110884294436,
+    "metric": "wer",
+    "trials": 100,
+    "engine": "whispers2t",
+    "created_at": "2026-02-23T03:47:17.668676"
+  }
+}

--- a/tests/vad/test_presets.py
+++ b/tests/vad/test_presets.py
@@ -110,10 +110,10 @@ class TestGetOptimizedPreset:
 class TestGetAvailablePresets:
     """Test get_available_presets function."""
 
-    def test_returns_21_combinations(self):
-        """Should return all 21 combinations (3 VADs x 2 languages x multiple engines)."""
+    def test_returns_27_combinations(self):
+        """Should return all 27 combinations (3 VADs x 2 languages x multiple engines)."""
         presets = get_available_presets()
-        assert len(presets) == 21
+        assert len(presets) == 27
 
     def test_returns_3_tuples(self):
         """Should return list of (vad_type, language, engine) tuples."""
@@ -228,7 +228,7 @@ class TestJSONPresetLoading:
             r.name for r in package.iterdir()
             if hasattr(r, "name") and r.name.endswith(".json")
         ]
-        assert len(json_files) == 21
+        assert len(json_files) == 27
 
     def test_all_json_files_are_valid_json(self):
         """All JSON files should parse without errors."""


### PR DESCRIPTION
## Summary

- whispers2t EN × 3 VAD + voxtral EN × 3 VAD の計 6 プリセットを追加（#265 で修正後の最適化結果）
- `optimize-vad.yml` の新規ファイル未検出バグを修正（`git diff` → `git add` + `git diff --cached`）
- テストのプリセット数アサーションを 21 → 27 に更新

### 追加プリセット

| ファイル | Engine | VAD | Best WER |
|---|---|---|---|
| `silero_en_whispers2t.json` | whispers2t | silero | 4.19% |
| `tenvad_en_whispers2t.json` | whispers2t | tenvad | 3.77% |
| `webrtc_en_whispers2t.json` | whispers2t | webrtc | 3.77% |
| `silero_en_voxtral.json` | voxtral | silero | 3.33% |
| `tenvad_en_voxtral.json` | voxtral | tenvad | 4.59% |
| `webrtc_en_voxtral.json` | voxtral | webrtc | 3.66% |

### ワークフローバグ修正

`optimize-vad.yml` で `git diff --name-only` が新規（untracked）プリセットファイルを検出できず、自動 PR 作成がスキップされていた。`git add` で先にステージングしてから `git diff --cached` で検出するよう修正。

## Test plan

- [x] `uv run pytest tests/ -k "preset"` — 全 88 テスト通過
- [x] `uv run pytest tests/benchmark_tests` — 全 185 テスト通過
- [x] プリセットローダーで 27 ファイル全てがバリデーション通過

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)