### PR TITLE
feat: NoiseGate hysteresis + hard-mute (Issue #280 PR B / C-1 + C-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,40 @@ Epic #64 (livecap-cli refactoring) - completion of all 6 phases.
 This represents the completion of a major refactoring effort spanning 6 phases.
 Package renamed from `livecap-core` to `livecap-cli`.
 
+### Changed
+
+#### **BREAKING** `NoiseGate` 既定挙動変更 (Issue [#280] PR B)
+
+- **Before** (PR [#279] / PR [#281]): 単一閾値 + `-60 dB` soft-mute
+- **After** (PR B): 自動ヒステリシス (`threshold_db - 6 dB`) + hard-mute (出力ゼロ)
+- **動機**: PR #281 の A/B 検証で、PR #281 までの挙動が whisper 系エンジンで flicker によるハルシネーション暴走 ("どうもどうも..." 等) を引き起こすことが実証された
+- **Migration**: 過去挙動を明示的に再現するには以下を指定:
+  ```python
+  NoiseGate(
+      threshold_db=-35,
+      close_threshold_db=-35,  # single-threshold (ヒステリシス無効)
+      noise_floor_db=-60,      # soft-mute
+  )
+  ```
+  CLI の場合:
+  ```bash
+  livecap-cli transcribe --noise-gate \
+      --noise-gate-threshold -35 \
+      --noise-gate-close-threshold -35 \
+      --noise-gate-floor -60 \
+      ...
+  ```
+
+新規オプション (既存呼び出しは無変更で動作、挙動のみ変化):
+
+- `NoiseGate` / `transcribe` CLI に `close_threshold_db` / `--noise-gate-close-threshold` を追加 (ヒステリシス制御)
+- `NoiseGate` / `transcribe` CLI に `noise_floor_db` / `--noise-gate-floor` を追加 (ゲート閉鎖時の減衰量制御)
+- 初期化ログが resolved 値 (open/close/noise_floor) を出力するように改善 (ポリシー準拠)
+
+既知の follow-up:
+
+- `release_ms=30` は PR B の新しい gate 挙動 (hard-mute による clean silence) に対して短すぎるため、攻撃的な閾値で fragmentation hallucination が発生することがあります。`--noise-gate-release 100` または `200` で回避可能。デフォルト値の変更は別 issue で対応予定。
+
 ### Added
 
 #### Noise Gate & Calibration ([#278], [#279], [#280], [#281])

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -406,10 +406,12 @@ transcriber = StreamTranscriber(
 
 ```python
 NoiseGate(
-    threshold_db: float = -35,   # 開放閾値 (dB)
-    attack_ms: float = 0.5,      # アタック時間 (ms)
-    release_ms: float = 30,      # リリース時間 (ms)
-    sample_rate: int = 16000,    # サンプリングレート (Hz)
+    threshold_db: float = -35,              # 開放閾値 (dB)
+    close_threshold_db: float | None = None,  # 閉鎖閾値 (dB), None = threshold_db - 6
+    attack_ms: float = 0.5,                 # アタック時間 (ms)
+    release_ms: float = 30,                 # リリース時間 (ms)
+    sample_rate: int = 16000,               # サンプリングレート (Hz)
+    noise_floor_db: float = float("-inf"),  # ゲート閉鎖時の減衰 (dB), 既定 = hard-mute
 )
 ```
 
@@ -417,10 +419,12 @@ NoiseGate(
 
 | パラメータ | 型 | デフォルト | 有効範囲 | 説明 |
 |-----------|-----|-----------|---------|------|
-| `threshold_db` | `float` | `-35` | `-80` ～ `0` | ゲート開放閾値。超過で無効値は警告 + `-35` にフォールバック |
+| `threshold_db` | `float` | `-35` | `-80` ～ `0` | 開放閾値。envelope がこれを超えるとゲートが開く |
+| `close_threshold_db` | `float \| None` | `None` (= `threshold_db - 6`) | `-80` ～ `threshold_db` | 閉鎖閾値。ゲート開放中、envelope がこれを下回ると閉じ始める。`None` は自動ヒステリシス (6 dB 下) |
 | `attack_ms` | `float` | `0.5` | `0.1` ～ `100` | エンベロープ上昇時定数 |
 | `release_ms` | `float` | `30` | `1` ～ `1000` | エンベロープ減衰時定数 |
 | `sample_rate` | `int` | `16000` | - | 音声のサンプリングレート |
+| `noise_floor_db` | `float` | `float("-inf")` (hard-mute) | `-120` ～ `0` または `-inf` | ゲート閉鎖時の減衰量。`-inf` で完全無音 (出力ゼロ)、有限値で `× 10^(dB/20)` 減衰 |
 
 ### メソッド
 
@@ -428,6 +432,25 @@ NoiseGate(
 |---------|--------|------|
 | `process(audio_chunk)` | `np.ndarray` | `float32` 1 次元チャンクにゲートを適用 |
 | `reset()` | `None` | 内部状態（envelope / gate_open / release_counter）をリセット |
+
+### ヒステリシスと hard-mute (Issue #280 C-1 / C-2)
+
+#### なぜヒステリシスが必要か
+
+単一閾値 (open == close) の場合、envelope が threshold 付近で振動するとゲートが急速に開閉を繰り返します (flicker)。断片化された音声が ASR エンジンに渡り、特に whisper 系ではハルシネーションを誘発します。
+
+**2 閾値方式** (open > close):
+- 閉状態では `envelope > open_threshold` で開く
+- 開状態では `envelope < close_threshold` で閉じ始める
+- `close_threshold < envelope < open_threshold` の「死のゾーン」では現在の状態を維持
+
+既定で `close_threshold_db = open_threshold - 6` を採用することで、6 dB 幅の hysteresis band を確保します。
+
+#### なぜ hard-mute が既定か
+
+従来 `-60 dB` の soft-mute (出力 × 0.001) は、ゲート閉鎖時にも残留信号が残ります。この残留が whisper の YouTube dataset バイアス (「ご視聴ありがとうございました」等) のトリガーになることが実測で確認されました ([PR #281 A/B 結果](https://github.com/Mega-Gorilla/livecap-cli/pull/281#issuecomment-4286562884))。
+
+`noise_floor_db = float("-inf")` を既定とし、ゲート閉鎖時は出力を完全ゼロにします。従来の soft-mute 挙動を望む場合は `noise_floor_db=-60` を明示的に指定してください。
 
 ### 使用例
 
@@ -438,8 +461,15 @@ from livecap_cli.audio import NoiseGate
 engine = EngineFactory.create_engine("whispers2t", device="cuda")
 engine.load_model()
 
-# ノイズゲートは levels コマンドで推奨値を取得可能
-gate = NoiseGate(threshold_db=-49, attack_ms=0.5, release_ms=30)
+# 既定: 自動ヒステリシス + hard-mute (推奨)
+gate = NoiseGate(threshold_db=-49)
+
+# 単一閾値挙動を明示的に望む場合 (pre-PR-B 互換)
+gate_legacy = NoiseGate(
+    threshold_db=-49,
+    close_threshold_db=-49,  # open == close で single-threshold
+    noise_floor_db=-60,      # soft-mute
+)
 
 transcriber = StreamTranscriber(engine=engine, noise_gate=gate)
 with MicrophoneSource() as mic:
@@ -449,7 +479,11 @@ with MicrophoneSource() as mic:
 
 ### 閾値決定のガイドライン
 
-環境ノイズに近い閾値（±5 dB の「死のゾーン」）は、ゲート頻繁開閉による疑似パルスで **逆にハルシネーションを増やします**。推奨値は `levels` コマンドまたは [`analyze_noise_samples()`](#noiseanalysis--analyze_noise_samples) で算出してください（`noise_peak + 10 dB` の保守的マージン）。
+環境ノイズに近い閾値（±5 dB の「死のゾーン」）は、ヒステリシスを入れても避けるべきです。推奨値は `levels` コマンドまたは [`analyze_noise_samples()`](#noiseanalysis--analyze_noise_samples) で算出してください（`noise_peak + 10 dB` の保守的マージン）。
+
+**攻撃的な閾値 (speech peak 付近) での tuning tips**:
+- `close_threshold_db` を下げると hysteresis band が広がり、より安定 (例: open=-20, close=-30)
+- `release_ms` を 100-200 ms に上げると発話間の brief pause で gate が閉じず、whisper のフラグメント hallucination を抑制 ([検証データ](https://github.com/Mega-Gorilla/livecap-cli/pull/281#issuecomment-4286562884))
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -146,23 +146,13 @@ livecap-cli transcribe --realtime --mic 0 \
   --noise-gate --noise-gate-threshold "$THRESHOLD"
 ```
 
-### ⚠️ `suggested_threshold_db` の位置づけ
+### `suggested_threshold_db` の位置づけ
 
-`suggested_threshold_db` は **「キャリブレーション済み出発点」** として設計された値で、環境ノイズから算出された **本命アルゴリズム後の推奨値** です。ただし現行 NoiseGate 本体はまだ先行導入段階です:
+`suggested_threshold_db` は **「キャリブレーション済み出発点」** です。現行 NoiseGate (自動ヒステリシス + hard-mute) に対してほぼそのまま使える値ですが、以下のケースでは追加チューニングが有効です:
 
-| | 現行 (PR #279 + PR #281) | Follow-up (Issue #280 の PR B で対応予定) |
-|---|---|---|
-| 閾値 | 単一閾値 | **ヒステリシス** (open/close 別閾値) |
-| ゲート閉鎖時 | soft-mute (`-60 dB` に減衰) | **hard-mute** (完全無音) |
-| Flicker 対策 | 無し | ヒステリシス + hard-mute で解決 |
-
-このため、現行実装では環境や発話音量によっては推奨値の追加調整が必要です:
-
-- **クリーンな環境 / 大きめの声量**: 推奨値そのままで OK
-- **ノイジーな環境 / 小さめの声量**: 推奨値より **低め** (より保守的) に調整
-  - 例: 推奨値 `-17 dB` で発話がゲート閉鎖される場合 → `-25 dB` や `-35 dB` に下げる
-- **whisper (whispers2t) エンジン利用時**: 特に影響を受けやすい。
-  推奨値が speech peak 付近の場合、gate flicker によるハルシネーション (「ご視聴ありがとうございました」等) が発生することがあります。この場合は閾値を下げるか、`reazonspeech` / `parakeet_ja` / `qwen3asr` 等の別エンジンを検討してください。
+- **攻撃的な閾値 (speech peak 付近) で fragmentation が出る場合**: `--noise-gate-release 100` (または `200`) と併用
+- **非常に静かな発話 / 極端な低 SNR 環境**: 手動で閾値を下げる
+- **whisper 系エンジンで残留ハルシネーションが気になる場合**: `reazonspeech` / `parakeet_ja` / `qwen3asr` に切り替えると whisper 固有のバイアス問題を回避できます
 
 詳細な背景は [Issue #280](https://github.com/Mega-Gorilla/livecap-cli/issues/280) を参照。
 
@@ -258,8 +248,10 @@ livecap-cli transcribe --realtime --mic 0 --vad silero
 | `--target-lang` | 翻訳先言語 | `en` |
 | `--noise-gate` | ノイズゲートを有効化（VAD 前段で環境ノイズを減衰） | `False` |
 | `--noise-gate-threshold` | ゲート開放閾値 (dB)。`levels` コマンドで推奨値を算出可能 | `-35` |
+| `--noise-gate-close-threshold` | ゲート閉鎖閾値 (dB)、ヒステリシス用。未指定なら open − 6 dB に自動解決 | `None` (auto) |
 | `--noise-gate-attack` | アタック時間 (ms) | `0.5` |
 | `--noise-gate-release` | リリース時間 (ms) | `30` |
+| `--noise-gate-floor` | ゲート閉鎖時の出力減衰 (dB)。未指定で hard-mute。`-60` を渡せば旧 soft-mute | `None` (hard-mute) |
 
 ### モデルサイズ（WhisperS2T）
 
@@ -322,16 +314,13 @@ livecap-cli transcribe --realtime --mic 0 \
   --noise-gate --noise-gate-threshold -49
 ```
 
-ノイズゲートは VAD の前段で音量ベースのゲーティングを行い、環境ノイズによる VAD 誤検出（ハルシネーションの原因）を抑制します。numba JIT で高速化されており、実時間比で無視できるオーバーヘッドで動作します。
+ノイズゲートは VAD の前段で音量ベースのゲーティングを行い、環境ノイズによる VAD 誤検出（ハルシネーションの原因）を抑制します。既定で自動ヒステリシス (`threshold_db - 6 dB`) + hard-mute が有効化されており、flicker による擬似パルス生成を抑制します。numba JIT で高速化されており、実時間比で無視できるオーバーヘッドで動作します。
 
-> **⚠️ 現行 NoiseGate は先行導入段階です**
-> 現行実装は単一閾値 + soft-mute で構成されており、閾値が speech peak 付近にある場合は flicker によって **逆にハルシネーションを増やす** ことがあります ([Issue #280](https://github.com/Mega-Gorilla/livecap-cli/issues/280))。
+> **💡 アドバンスドチューニング**
 >
-> **エンジン別の実地ガイダンス**:
-> - **`whispers2t`**: YouTube dataset バイアスにより flicker で「ご視聴ありがとう...」等のハルシネーションが発生しやすい。`levels` の推奨値ではなく **保守的な値** (例: `noise_floor + 5 dB`) を使うか、別エンジンを推奨。
-> - **`reazonspeech` / `parakeet_ja` / `qwen3asr`**: CTC / 別アーキテクチャのため flicker への耐性が高く、`levels` の推奨値をそのまま使用可。
->
-> [Issue #280](https://github.com/Mega-Gorilla/livecap-cli/issues/280) の follow-up (PR B: ヒステリシス + hard-mute) 完了後は、推奨値 (`noise_peak + 10 dB`) がより安定して使えるようになります。
+> - **攻撃的な閾値 (speech peak 付近) を試す場合**: `--noise-gate-release 100` や `200` を併用すると、発話間の brief pause でゲートが閉じず、whisper 系で出やすい「んんん...」のフラグメントハルシネーションを抑制できます ([PR B 内の検証データ](https://github.com/Mega-Gorilla/livecap-cli/pull/281#issuecomment-4286562884))。
+> - **旧挙動 (PR #281 までの単一閾値 + `-60 dB` soft-mute) を再現したい場合**: `--noise-gate-close-threshold` に `--noise-gate-threshold` と同じ値を渡し、`--noise-gate-floor -60` を指定します。
+> - **死のゾーン回避**: 閾値を `noise_floor ± 5 dB` 範囲に設定しないでください。`levels` コマンドの `danger_zone` を確認し、`suggested_threshold_db` を出発点にしてください。
 
 ---
 

--- a/livecap_cli/audio/noise_gate.py
+++ b/livecap_cli/audio/noise_gate.py
@@ -9,6 +9,7 @@ livecap-gui v2 の RealtimeNoiseGate から移植。numba で高速化。
 from __future__ import annotations
 
 import logging
+import math
 
 import numba
 import numpy as np
@@ -23,7 +24,8 @@ def _process_loop(
     envelope: float,
     gate_open: int,
     release_counter: int,
-    threshold: float,
+    open_threshold: float,
+    close_threshold: float,
     attack_coeff: float,
     release_coeff: float,
     release_samples: int,
@@ -33,6 +35,11 @@ def _process_loop(
 
     サンプル単位の逐次処理でエンベロープフォロワーとゲート判定を行う。
     状態管理のためベクトル化ではなくループ処理を採用。
+
+    ヒステリシス:
+    - ``open_threshold``: 閉じた状態からゲートを開くには envelope がこれを超える必要がある。
+    - ``close_threshold``: 開いた状態でゲートを閉じ始めるには envelope がこれを下回る必要がある。
+    - ``open_threshold == close_threshold`` の場合は単一閾値挙動 (ヒステリシスなし)。
     """
     for i in range(len(audio)):
         abs_sample = abs(audio[i])
@@ -45,16 +52,25 @@ def _process_loop(
             # リリース（エンベロープを減衰）
             envelope *= 1.0 - release_coeff
 
-        # ゲート判定（リリースカウンターでホールド時間を実装）
-        if envelope > threshold:
-            gate_open = 1
-            release_counter = release_samples
-        elif release_counter > 0:
-            release_counter -= 1
+        # ゲート判定（ヒステリシス + リリースカウンターでホールド時間）
+        if gate_open:
+            # 開いた状態では close_threshold を判定条件に使う
+            if envelope > close_threshold:
+                # ヒステリシス band 内または上 → hold (counter リセット)
+                release_counter = release_samples
+            else:
+                # close_threshold を下回った → リリース開始
+                if release_counter > 0:
+                    release_counter -= 1
+                else:
+                    gate_open = 0
         else:
-            gate_open = 0
+            # 閉じた状態では open_threshold を超えないと開かない
+            if envelope > open_threshold:
+                gate_open = 1
+                release_counter = release_samples
 
-        # 出力（ゲートが閉じている時はノイズフロアレベルに減衰）
+        # 出力（ゲートが閉じている時は noise_floor レベルに減衰; 0.0 なら hard-mute）
         if gate_open:
             output[i] = audio[i]
         else:
@@ -74,16 +90,52 @@ class NoiseGate:
     def __init__(
         self,
         threshold_db: float = -35,
+        close_threshold_db: float | None = None,
         attack_ms: float = 0.5,
         release_ms: float = 30,
         sample_rate: int = 16000,
+        noise_floor_db: float = float("-inf"),
     ) -> None:
+        """NoiseGate を初期化。
+
+        Args:
+            threshold_db: ゲートを開く閾値 (dB, ``-80`` ～ ``0``)。
+            close_threshold_db: ヒステリシス閉鎖閾値 (dB)。
+                ``None`` 既定では ``threshold_db - 6 dB`` に自動解決される。
+                単一閾値挙動 (ヒステリシスなし) が欲しい場合は
+                ``close_threshold_db=threshold_db`` を明示的に指定する。
+            attack_ms: アタック時間 (ms, ``0.1`` ～ ``100``)。
+            release_ms: リリース時間 (ms, ``1`` ～ ``1000``)。
+            sample_rate: サンプリングレート (Hz)。
+            noise_floor_db: ゲート閉鎖時の出力減衰 (dB)。既定 ``float("-inf")``
+                は hard-mute (出力完全ゼロ)。``-60`` のような有限値を明示的に
+                指定すると soft-mute になる (旧挙動の再現)。
+                有限値の範囲: ``-120`` ～ ``0``。
+        """
         # パラメータ検証（v2 から移植）
         if not -80 <= threshold_db <= 0:
             logger.warning(
                 "Invalid threshold %sdB, using -35dB", threshold_db
             )
             threshold_db = -35
+
+        # close_threshold_db の解決 (None → auto hysteresis)
+        if close_threshold_db is None:
+            close_threshold_db = threshold_db - 6.0
+        if close_threshold_db > threshold_db:
+            logger.warning(
+                "close_threshold_db (%sdB) > threshold_db (%sdB); "
+                "clamping to threshold_db (no hysteresis)",
+                close_threshold_db,
+                threshold_db,
+            )
+            close_threshold_db = float(threshold_db)
+        if close_threshold_db < -80:
+            logger.warning(
+                "close_threshold_db (%sdB) < -80; clamping to -80",
+                close_threshold_db,
+            )
+            close_threshold_db = -80.0
 
         if not 0.1 <= attack_ms <= 100:
             logger.warning(
@@ -97,7 +149,25 @@ class NoiseGate:
             )
             release_ms = 30
 
-        self._threshold = 10 ** (threshold_db / 20)
+        # noise_floor_db の検証 + 線形値への変換
+        if not math.isfinite(noise_floor_db):
+            # -inf (hard-mute) or nan 等
+            self._noise_floor = 0.0
+            noise_floor_db_resolved: float | None = None  # for logging
+        elif -120 <= noise_floor_db <= 0:
+            self._noise_floor = 10 ** (noise_floor_db / 20)
+            noise_floor_db_resolved = noise_floor_db
+        else:
+            logger.warning(
+                "Invalid noise_floor_db %sdB; using -inf (hard-mute)",
+                noise_floor_db,
+            )
+            self._noise_floor = 0.0
+            noise_floor_db_resolved = None
+
+        # 線形スレッショルド
+        self._threshold = 10 ** (threshold_db / 20)  # open threshold (互換名)
+        self._close_threshold = 10 ** (close_threshold_db / 20)
         self._attack_samples = max(1, int(attack_ms * sample_rate / 1000))
         self._release_samples = max(1, int(release_ms * sample_rate / 1000))
 
@@ -105,17 +175,19 @@ class NoiseGate:
         self._attack_coeff = 1.0 - np.exp(-1.0 / self._attack_samples)
         self._release_coeff = 1.0 - np.exp(-1.0 / self._release_samples)
 
-        # ノイズフロア（ゲートが閉じた時の減衰量: -60dB）
-        self._noise_floor = 10 ** (-60 / 20)
-
         # ゲート状態
         self._envelope: float = 0.0
         self._gate_open: int = 0  # numba 互換のため int (0/1)
         self._release_counter: int = 0
 
         logger.info(
-            "NoiseGate initialized: threshold=%sdB, attack=%sms, release=%sms",
+            "NoiseGate initialized: open=%.1fdB, close=%.1fdB, "
+            "noise_floor=%s, attack=%.1fms, release=%.1fms",
             threshold_db,
+            close_threshold_db,
+            "-inf (hard-mute)"
+            if noise_floor_db_resolved is None
+            else f"{noise_floor_db_resolved:.1f}dB",
             attack_ms,
             release_ms,
         )
@@ -141,6 +213,7 @@ class NoiseGate:
             self._gate_open,
             self._release_counter,
             self._threshold,
+            self._close_threshold,
             self._attack_coeff,
             self._release_coeff,
             self._release_samples,

--- a/livecap_cli/cli.py
+++ b/livecap_cli/cli.py
@@ -294,11 +294,10 @@ def cmd_levels(args: argparse.Namespace) -> int:
                 )
                 print(
                     "Note: The suggested value is a calibrated starting "
-                    "point. With the current NoiseGate (pre-hysteresis / "
-                    "soft-mute), quiet speech or low-SNR environments may "
-                    "need a more conservative threshold. "
-                    "See Issue #280 for the follow-up hysteresis + "
-                    "hard-mute work.",
+                    "point for the current NoiseGate "
+                    "(auto hysteresis + hard-mute). Very quiet speech or "
+                    "extreme low-SNR conditions may still need manual "
+                    "tuning.",
                     file=sys.stderr,
                 )
 
@@ -437,8 +436,14 @@ def _transcribe_realtime(args: argparse.Namespace) -> int:
 
             noise_gate = NoiseGate(
                 threshold_db=args.noise_gate_threshold,
+                close_threshold_db=args.noise_gate_close_threshold,
                 attack_ms=args.noise_gate_attack,
                 release_ms=args.noise_gate_release,
+                noise_floor_db=(
+                    args.noise_gate_floor
+                    if args.noise_gate_floor is not None
+                    else float("-inf")
+                ),
             )
 
         # Start transcription
@@ -664,6 +669,26 @@ def main(argv: list[str] | None = None) -> int:
         type=float,
         default=30,
         help="Noise gate release time in ms (default: 30)",
+    )
+    transcribe_parser.add_argument(
+        "--noise-gate-close-threshold",
+        type=float,
+        default=None,
+        help=(
+            "Noise gate close threshold in dB for hysteresis "
+            "(default: open threshold - 6 dB; "
+            "pass the same value as --noise-gate-threshold to disable hysteresis)"
+        ),
+    )
+    transcribe_parser.add_argument(
+        "--noise-gate-floor",
+        type=float,
+        default=None,
+        help=(
+            "Noise floor in dB when gate is closed "
+            "(default: hard-mute / -inf; "
+            "pass e.g. -60 for legacy soft-mute behavior)"
+        ),
     )
     transcribe_parser.set_defaults(func=cmd_transcribe)
 

--- a/tests/audio/test_noise_gate.py
+++ b/tests/audio/test_noise_gate.py
@@ -19,6 +19,10 @@ class TestNoiseGateInit:
     def test_default_parameters(self):
         ng = NoiseGate()
         assert ng._threshold == pytest.approx(10 ** (-35 / 20))
+        # PR B: close_threshold_db=None は threshold - 6 dB に解決
+        assert ng._close_threshold == pytest.approx(10 ** (-41 / 20))
+        # PR B: noise_floor_db=-inf が既定 → hard-mute (noise_floor = 0.0)
+        assert ng._noise_floor == 0.0
         assert ng._envelope == 0.0
         assert ng._gate_open == 0
         assert ng._release_counter == 0
@@ -26,6 +30,8 @@ class TestNoiseGateInit:
     def test_custom_parameters(self):
         ng = NoiseGate(threshold_db=-50, attack_ms=1.0, release_ms=50, sample_rate=16000)
         assert ng._threshold == pytest.approx(10 ** (-50 / 20))
+        # auto hysteresis: threshold - 6 = -56 dB
+        assert ng._close_threshold == pytest.approx(10 ** (-56 / 20))
 
     def test_invalid_threshold_clamped(self):
         """範囲外の threshold はデフォルト値にフォールバック。"""
@@ -109,6 +115,129 @@ class TestNoiseGateProcess:
         audio = np.zeros(100, dtype=np.float32)
         output = ng.process(audio)
         assert output.dtype == audio.dtype
+
+
+# === ヒステリシス / hard-mute テスト (PR B / Issue #280 C-1, C-2) ===
+
+
+class TestHysteresis:
+    """close_threshold_db によるヒステリシス挙動のテスト。"""
+
+    def test_auto_close_threshold_default(self):
+        """close_threshold_db=None → threshold_db - 6 dB に自動解決。"""
+        ng = NoiseGate(threshold_db=-35)
+        assert ng._close_threshold == pytest.approx(10 ** (-41 / 20))
+
+    def test_explicit_close_threshold(self):
+        """明示的 close_threshold_db が使われる。"""
+        ng = NoiseGate(threshold_db=-35, close_threshold_db=-50)
+        assert ng._close_threshold == pytest.approx(10 ** (-50 / 20))
+
+    def test_legacy_single_threshold_opt_in(self):
+        """close_threshold_db=threshold_db で legacy 単一閾値挙動 (ヒステリシスなし)。"""
+        ng = NoiseGate(threshold_db=-35, close_threshold_db=-35)
+        assert ng._threshold == ng._close_threshold
+
+    def test_close_threshold_above_open_clamped(self, caplog):
+        """close > open は警告 + threshold_db に clamp (= 単一閾値)。"""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            ng = NoiseGate(threshold_db=-35, close_threshold_db=-20)
+        assert "close_threshold" in caplog.text.lower()
+        assert ng._close_threshold == ng._threshold
+
+    def test_close_threshold_below_minus_80_clamped(self, caplog):
+        """close < -80 は警告 + -80 に clamp。"""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            ng = NoiseGate(threshold_db=-35, close_threshold_db=-100)
+        assert "close_threshold" in caplog.text.lower()
+        assert ng._close_threshold == pytest.approx(10 ** (-80 / 20))
+
+    def test_hysteresis_prevents_flicker(self):
+        """threshold 付近を振動する envelope でも gate 状態が安定 (flicker 抑制)。
+
+        open=-35, close=-41 (デフォルト 6 dB band) に対し、入力を
+        -34 dB と -37 dB で振動させる。-37 dB は close (-41) を
+        下回らないため、ゲートは一度開いたら閉じない。
+        """
+        ng = NoiseGate(threshold_db=-35, release_ms=5, sample_rate=16000)
+        # -34 dB ≈ 0.02, -37 dB ≈ 0.0141 (両方 close=-41 より上)
+        hi = float(10 ** (-34 / 20))
+        lo = float(10 ** (-37 / 20))
+        samples = np.array([hi, lo] * 800, dtype=np.float32)
+        ng.process(samples)
+        # 振動しても最後まで開いたまま
+        assert ng._gate_open == 1
+
+    def test_hysteresis_allows_clean_close(self):
+        """close_threshold をしっかり下回れば gate は閉じる。"""
+        ng = NoiseGate(threshold_db=-35, release_ms=5, sample_rate=16000)
+        # 前半: -10 dB で gate 開く
+        loud = np.full(800, 0.3, dtype=np.float32)
+        # 後半: -80 dB で gate close (close=-41 より十分下)
+        silent = np.full(1600, 0.0001, dtype=np.float32)
+        samples = np.concatenate([loud, silent])
+        ng.process(samples)
+        # release + envelope decay 後は閉じる
+        assert ng._gate_open == 0
+
+
+class TestHardMute:
+    """noise_floor_db パラメータ化と hard-mute のテスト。"""
+
+    def test_hard_mute_default(self):
+        """既定 (noise_floor_db=-inf) で hard-mute、ゲート閉鎖時の出力は完全ゼロ。"""
+        ng = NoiseGate(threshold_db=-35)
+        assert ng._noise_floor == 0.0
+        # 閾値以下の無音入力 → gate 閉鎖 → 出力ゼロ
+        silence = np.full(1600, 0.0001, dtype=np.float32)
+        output = ng.process(silence)
+        assert np.all(output == 0.0)
+
+    def test_soft_mute_opt_in_negative_60(self):
+        """noise_floor_db=-60 で legacy soft-mute (出力 = 入力 × 0.001)。"""
+        ng = NoiseGate(threshold_db=-35, noise_floor_db=-60)
+        assert ng._noise_floor == pytest.approx(10 ** (-60 / 20))
+        # 閾値以下の無音入力 → gate 閉鎖 → 出力 = 入力 × 0.001
+        silence = np.full(1600, 0.0001, dtype=np.float32)
+        output = ng.process(silence)
+        # すべて hard-mute ではない (ゼロより大きい値が残る)
+        assert np.max(np.abs(output)) > 0.0
+        assert np.allclose(output, silence * ng._noise_floor, atol=1e-8)
+
+    def test_inf_explicit_hard_mute(self):
+        """float('-inf') を明示指定しても hard-mute。"""
+        ng = NoiseGate(threshold_db=-35, noise_floor_db=float("-inf"))
+        assert ng._noise_floor == 0.0
+
+    def test_noise_floor_out_of_range_warning(self, caplog):
+        """noise_floor_db > 0 は警告 + fallback to hard-mute。"""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            ng = NoiseGate(threshold_db=-35, noise_floor_db=10)
+        assert "noise_floor" in caplog.text.lower()
+        assert ng._noise_floor == 0.0
+
+    def test_noise_floor_too_low_warning(self, caplog):
+        """noise_floor_db < -120 は警告 + fallback to hard-mute。"""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            ng = NoiseGate(threshold_db=-35, noise_floor_db=-150)
+        assert "noise_floor" in caplog.text.lower()
+        assert ng._noise_floor == 0.0
+
+    def test_gate_open_not_affected_by_noise_floor(self):
+        """ゲート開放時は noise_floor に関わらず入力をパススルー。"""
+        ng = NoiseGate(threshold_db=-35, noise_floor_db=float("-inf"))
+        loud = np.full(1600, 0.3, dtype=np.float32)
+        output = ng.process(loud)
+        # 開いてからは loud そのまま (hard-mute 設定でも影響なし)
+        assert np.allclose(output[50:], loud[50:], atol=1e-6)
 
 
 # === reset() テスト ===

--- a/tests/core/cli/test_cli.py
+++ b/tests/core/cli/test_cli.py
@@ -140,6 +140,9 @@ class TestCLINoiseGateOptions:
         assert "--noise-gate-threshold" in help_text
         assert "--noise-gate-attack" in help_text
         assert "--noise-gate-release" in help_text
+        # PR B additions (Issue #280 C-1/C-2)
+        assert "--noise-gate-close-threshold" in help_text
+        assert "--noise-gate-floor" in help_text
 
     def test_levels_command_in_help(self, capsys: pytest.CaptureFixture) -> None:
         """levels コマンドが help に表示される。"""


### PR DESCRIPTION
## Summary

Issue #280 の **PR B (C-1 + C-2)**。NoiseGate 本体を安定化し、PR #281 の A/B 検証で実証された whisper ハルシネーション暴走 (閾値 -20 dB で 423 chars の「どうもどうも...」ループ) を解消します。

### 主な変更

1. **C-1: ヒステリシス** — `close_threshold_db: float | None = None` 追加
   - `None` 既定で `threshold_db - 6 dB` に自動解決 (6 dB 幅の hysteresis band)
   - 単一閾値挙動を望むユーザーは `close_threshold_db=threshold_db` を明示
2. **C-2: Hard-mute** — `noise_floor_db: float = float("-inf")` 追加
   - 既定で hard-mute (ゲート閉鎖時の出力が完全ゼロ)
   - 旧 soft-mute を望むユーザーは `noise_floor_db=-60` を明示
3. **CLI 統合** — `transcribe --noise-gate-close-threshold` / `--noise-gate-floor` を追加
4. **情報豊富な初期化ログ** — `open=-35.0dB, close=-41.0dB, noise_floor=-inf (hard-mute), ...` (AGENTS.md ポリシー準拠)

## 後方互換について (pre-1.0 policy 準拠)

`AGENTS.md` の Backward Compatibility Policy に従い、**バグ保存のための legacy flag は追加しません**。既存呼び出し `NoiseGate(threshold_db=X, attack_ms=Y, release_ms=Z)` は動作継続しますが挙動が変化します。過去挙動を明示的に再現したい場合は:

```python
NoiseGate(
    threshold_db=-35,
    close_threshold_db=-35,  # single-threshold (disable hysteresis)
    noise_floor_db=-60,      # soft-mute (pre-PR-B default)
)
```

CHANGELOG に BREAKING note + migration を記載済み。

## 実測 A/B 結果 (PR #281 比)

`neko_reference_noisy.wav` (noise_floor ≈ -33 dB, speech_peak ≈ -12 dB) での実測:

### whispers2t

| 閾値 | PR #281 | **PR B** | Delta | 備考 |
|---|---|---|---|---|
| baseline | 99c | 103c | +4 | 誤差範囲 |
| -35 dB (default) | 102c | 101c | -1 | 変化なし (既定 threshold では close = -41 が十分低く影響小) |
| -25 dB | 105c | 316c ⚠️ | **+211** | 新種 fragmentation ("んんん...") — release_ms 調整で解消 |
| **-20 dB** | **423c 🔥** | **88c** ✅ | **-335** | **🎯 primary target FIXED** |
| -17 dB | 103c | 300c ⚠️ | +197 | 同上 fragmentation |

### parakeet_ja

| 閾値 | PR #281 | **PR B** | Delta |
|---|---|---|---|
| baseline | 93c | 93c | 0 |
| -35 dB | 94c | 94c | 0 |
| -25 dB | 98c | 98c | 0 |
| -20 dB | 103c ⚠️ | **95c** ✅ | -8 |
| -17 dB | 102c ⚠️ | **95c** ✅ | -7 |

→ **parakeet_ja は全 configurations で改善**。whisper 以外のエンジンへの副作用なし。

### 新種 fragmentation の原因分析

hard-mute により silence が clean になった結果、phrase 間の brief pause で gate が閉じ、VAD が分断された speech 断片を whisper に送ります。whisper はその短断片から「んんん...」のセーフフレーズを hallucinate します。

**実証済み対症療法** (follow-up issue 想定):

| threshold | release=30 (default) | release=100 | release=200 |
|---|---|---|---|
| -25 dB | 316c 🔥 | **102c** ✅ | **102c** ✅ |
| -17 dB | 299c 🔥 | **96c** ✅ | **86c** ✅ |

`release_ms=100` で完全解消。ユーザーは今すぐ `--noise-gate-release 100` で回避できます。デフォルト値の変更は別 issue で対応予定 (本 PR スコープ外の合意事項)。

## Test plan

- [x] `uv run pytest tests/audio/ tests/core/cli/` — **46/46 passed** (13 新規 + 33 既存)
- [x] numba JIT benchmark pass (< 1 ms/chunk 維持)
- [x] `uv run livecap-cli transcribe --help` で新オプション表示を確認
- [x] A/B 回帰テスト (whispers2t + parakeet_ja, 5 configurations)
- [x] 初期化ログが `open=...dB, close=...dB, noise_floor=-inf (hard-mute)` を出力
- [ ] hosted CI (次回 push で実行)

## ⚠️ リリースノート

NoiseGate 既定挙動変更 (BREAKING):

| | Before (PR #279/#281) | After (PR B) |
|---|---|---|
| 閾値 | 単一閾値 | 自動ヒステリシス (`-6 dB` band) |
| ゲート閉鎖時 | `-60 dB` soft-mute | hard-mute (完全ゼロ) |
| whispers2t @ -20 dB | 423 chars (暴走) | 88 chars (正常) |

CHANGELOG.md に Before/After/Migration を記載済み。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `livecap_cli/audio/noise_gate.py` | `_process_loop` に close_threshold 追加 + hysteresis logic + `__init__` に 2 パラメータ + 情報豊富ログ |
| `livecap_cli/cli.py` | `--noise-gate-close-threshold` / `--noise-gate-floor` 追加 + cmd_levels 注意書き緩和 |
| `tests/audio/test_noise_gate.py` | `TestHysteresis` (7 tests) + `TestHardMute` (6 tests) 追加、既存 defaults 更新 |
| `tests/core/cli/test_cli.py` | parse テストに新オプション追加 |
| `docs/reference/api.md` | NoiseGate section に新パラメータ + hysteresis/hard-mute 説明 |
| `docs/reference/cli.md` | option 表拡張 + 警告ブロック刷新 (アドバンスドチューニング) |
| `CHANGELOG.md` | `### Changed` に BREAKING note (before/after/migration + release_ms follow-up) |

## Follow-up (本 PR 範囲外)

- **`release_ms` デフォルト再評価**: 現行 30ms では hard-mute 下でフラグメント化を招く (A/B 実証済み)。100-200ms に引き上げる別 issue を作成予定
- A/B ハーネス (`.tmp/noise_gate_ab_test.py`) の `tests/benchmark/` への昇格検討

## 関連

- Issue #280 (親 issue, C-1 + C-2)
- PR #281 (PR A, キャリブレーション API 基盤)
- livecap-gui PR #294 (推奨マージン +10 dB の根拠)
- `AGENTS.md` § Backward Compatibility Policy (pre-1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)