### PR TITLE
fix(audio): peak-based NoiseAnalysis calibration (#291)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,52 @@ Package renamed from `livecap-core` to `livecap-cli`.
 
 ### Changed
 
+#### **BREAKING** `NoiseAnalysis` / `analyze_noise_samples()` を peak-based calibration に置換 (Issue [#291])
+
+- **Before**: `analyze_noise_samples(samples_db, sample_rate_hz)` →
+  `suggested_threshold_db = noise_peak (chunk RMS p95) + 10 dB`
+- **After**: `analyze_noise_samples(samples_db, peak_samples_db, sample_rate_hz)` →
+  `suggested_threshold_db = peak_p95 (per-chunk |x|.max() p95) + 6 dB`
+- **動機**: `NoiseGate` (`livecap_cli/audio/noise_gate.py`) の envelope follower
+  は per-sample peak を追跡するが、calibration は chunk RMS を計測していた → unit
+  mismatch により impulsive noise (キーボード/呼吸/breath bursts) で threshold が
+  peak の下に潜り、無音時 hallucination ("あ"/"うん"/"ピッ") を引き起こしていた
+  (Mega-Gorilla/livecap-gui#331 root-cause)。White noise の crest factor ≈ 11 dB
+  が偶然 `+10` で吸収されていたが、impulsive noise では crest factor がより大きく
+  破綻する。
+- **API 変更点**:
+  - `NoiseAnalysis` 新 field: `peak_p95_db: float` (per-chunk `|x|.max()` の 95%ile)
+  - `NoiseAnalysis` 改名: `noise_peak_db` → `noise_rms_p95_db` (unit を field 名に明示)
+  - `NoiseAnalysis` 削除: `safe_zone_min_db` (新 `suggested_threshold_db` と 1 dB 差で意味崩壊)
+  - `analyze_noise_samples()` 新 required 引数: `peak_samples_db` (Optional=None の
+    legacy default は無し: pre-1.0 backward-compat policy で旧バグ温存の flag は不可)
+  - 新 module-level 定数: `livecap_cli.audio.PEAK_SAFETY_MARGIN_DB = 6.0`
+  - `danger_zone` は据え置き (RMS-unit diagnostic として docstring で明記)
+- **Migration**:
+  ```python
+  # 旧
+  rms_db_list = [20*log10(rms(chunk)) for chunk in chunks]
+  a = analyze_noise_samples(rms_db_list)
+
+  # 新
+  rms_db_list  = [20*log10(rms(chunk))    for chunk in chunks]
+  peak_db_list = [20*log10(|chunk|.max()) for chunk in chunks]
+  a = analyze_noise_samples(rms_db_list, peak_db_list)
+  # a.noise_peak_db    -> a.noise_rms_p95_db
+  # a.safe_zone_min_db -> (削除; suggested_threshold_db を直接使用)
+  # a.peak_p95_db      -> 新 field; threshold の基準
+  ```
+  CLI `levels` は内部で per-chunk peak を収集するように移行済みのため、
+  外部から CLI を呼ぶ場合の変更は不要 (JSON schema のみ変更)。
+- **検証**: `tests/audio/test_noise_gate_calibration.py` (新規) で synthetic
+  impulsive noise を旧 / 新 threshold それぞれで NoiseGate に通し、旧で gate
+  が開く / 新で閉じ続けることを assert する end-to-end 回帰テストを追加。
+- **GUI ペア PR**: livecap-gui 側は `core/noise_statistics.py` を削除し本 API
+  に委譲する PR を別 issue (Mega-Gorilla/livecap-gui#335 の対) で受ける。
+- **将来 follow-up**: NoiseGate の envelope follower を calibration 入力に対して
+  simulate し envelope の 95%ile を取れば margin を 1-2 dB に縮められる ([#283]
+  と組で別 issue 化予定)。
+
 #### **BREAKING** `NoiseGate` デフォルト `release_ms` 変更 (Issue [#283] PR C)
 
 - **Before** (PR #279 / PR #281 / PR #282): `release_ms=30`
@@ -314,3 +360,4 @@ print(result.to_srt_entry(index=1))
 [#280]: https://github.com/Mega-Gorilla/livecap-cli/issues/280
 [#281]: https://github.com/Mega-Gorilla/livecap-cli/pull/281
 [#283]: https://github.com/Mega-Gorilla/livecap-cli/issues/283
+[#291]: https://github.com/Mega-Gorilla/livecap-cli/issues/291

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -491,36 +491,44 @@ with MicrophoneSource() as mic:
 
 `livecap_cli.audio.analysis` — 録音したノイズサンプル列から推奨閾値・危険ゾーンを算出する純関数。CLI `levels` コマンドと GUI キャリブレーション UI から共通 API として使用されます。
 
+`NoiseGate` (`livecap_cli/audio/noise_gate.py`) は **per-sample envelope follower** で判定するため、calibration も **per-chunk peak (`|x|.max()`)** を入力にして単位を揃えます。`samples_db` (chunk RMS) は noise floor / RMS p95 の diagnostic としてのみ使用し、`suggested_threshold_db` は `peak_p95 + PEAK_SAFETY_MARGIN_DB` で求めます (issue [#291])。
+
 ### `NoiseAnalysis` dataclass
 
 ```python
+PEAK_SAFETY_MARGIN_DB = 6.0  # module-level 公開
+
 @dataclass(frozen=True)
 class NoiseAnalysis:
-    noise_floor_db: float           # 25 パーセンタイル（典型的な静音レベル）
-    noise_peak_db: float            # 95 パーセンタイル（偶発的ピーク）
-    suggested_threshold_db: float   # noise_peak_db + 10 dB（推奨閾値）
-    danger_zone: tuple[float, float]  # (floor - 5, floor + 5) — 避けるべき領域
-    safe_zone_min_db: float         # noise_peak + 5 dB
+    noise_floor_db: float          # RMS p25 (RMS-unit, diagnostic)
+    noise_rms_p95_db: float        # RMS p95 (RMS-unit, diagnostic)
+    peak_p95_db: float             # per-chunk |x|.max() の 95%ile (peak-unit)
+    suggested_threshold_db: float  # = peak_p95_db + PEAK_SAFETY_MARGIN_DB
+    danger_zone: tuple[float, float]  # floor ± 5 (RMS-unit diagnostic)
     sample_count: int
     duration_s: float
 ```
+
+`danger_zone` は **RMS-unit の diagnostic**: 手動で閾値をこの RMS 範囲に設定すると floor の揺らぎで gate がフリッカーするため避けるべき領域です。`suggested_threshold_db` は peak-unit のため直接比較できません。
 
 ### `analyze_noise_samples()`
 
 ```python
 def analyze_noise_samples(
     samples_db: Sequence[float] | np.ndarray,
+    peak_samples_db: Sequence[float] | np.ndarray,
     sample_rate_hz: float = 10.0,
 ) -> NoiseAnalysis:
 ```
 
 | パラメータ | 型 | 説明 |
 |-----------|-----|------|
-| `samples_db` | `Sequence[float]` / `np.ndarray` | dB 単位のレベルサンプル列（RMS を `20 * log10` したもの） |
-| `sample_rate_hz` | `float` | サンプル取得レート（`duration_s` の計算に使用） |
+| `samples_db` | `Sequence[float]` / `np.ndarray` | chunk RMS の dB 列 (`20*log10(rms(chunk))`) |
+| `peak_samples_db` | `Sequence[float]` / `np.ndarray` | chunk peak の dB 列 (`20*log10(|chunk|.max())`)。`len(peak_samples_db) == len(samples_db)` でなければならない |
+| `sample_rate_hz` | `float` | chunk 取得レート (`duration_s` の計算用) |
 
 **例外**:
-- `ValueError` — `samples_db` が空、または `sample_rate_hz <= 0`
+- `ValueError` — `samples_db` / `peak_samples_db` が空、長さ不一致、または `sample_rate_hz <= 0`
 
 ### 使用例
 
@@ -528,28 +536,27 @@ def analyze_noise_samples(
 import numpy as np
 from livecap_cli.audio import analyze_noise_samples
 
-# マイクから 5 秒分の RMS レベル（10 Hz で 50 サンプル）
-samples_db = [-72.3, -71.8, -70.5, ..., -58.2]
+# マイクから 5 秒分のレベル（10 Hz で 50 chunk × RMS + peak）
+rms_db_list  = [-72.3, -71.8, -70.5, ..., -58.2]   # 20*log10(rms(chunk))
+peak_db_list = [-58.0, -57.5, -57.1, ..., -45.0]   # 20*log10(|chunk|.max())
 
-analysis = analyze_noise_samples(samples_db, sample_rate_hz=10.0)
+analysis = analyze_noise_samples(rms_db_list, peak_db_list, sample_rate_hz=10.0)
 print(f"Suggested threshold: {analysis.suggested_threshold_db:.1f} dB")
-print(f"Danger zone: {analysis.danger_zone}")
+print(f"Peak p95: {analysis.peak_p95_db:.1f} dB")
+print(f"Danger zone (RMS): {analysis.danger_zone}")
 
-# NoiseGate に直接適用
+# NoiseGate に直接適用 (単位が揃っているため安全に渡せる)
 from livecap_cli.audio import NoiseGate
 gate = NoiseGate(threshold_db=analysis.suggested_threshold_db)
 ```
 
-### 推奨マージンの根拠
+### `PEAK_SAFETY_MARGIN_DB` の根拠
 
-| マージン（閾値 − ノイズフロア） | ゲート動作 | ハルシネーション |
-|--------------------------------|----------|-----------------|
-| `> +15 dB` | 常時閉鎖 | 最少 ⭐ |
-| `+5 ～ +15 dB` | 低頻度開閉 | 少 |
-| `-5 ～ +5 dB` | 頻繁に flicker | **激増** 🔥 |
-| `< -5 dB` | 常時開放 | Raw と同等 |
+`+6 dB` は NoiseGate 既定 (`attack_ms=0.5`, `release_ms=100`, `sample_rate=16000`) に対する実測ベースのマージン (livecap-gui [#331] root-cause 調査)。`attack_ms` を大幅に短くすると envelope の peak 追従が鋭くなるため margin の見直しが必要。
 
-出典: [livecap-gui PR #294 実測](https://github.com/Mega-Gorilla/livecap-gui/pull/294)。`noise_peak + 10 dB` は +10 dB 以上の安全ゾーンを保証します。
+> **Note (issue [#291])**: 旧実装は `noise_peak (chunk RMS p95) + 10 dB` を推奨値としており、White noise の crest factor ≈ 11 dB が偶然 `+10` で吸収されていただけでした。impulsive noise (キーボード/呼吸/breath bursts) では crest factor が大きくなり threshold が peak の下に潜り、envelope follower が瞬間超え → 無音時 hallucination ("あ"/"うん"/"ピッ") を引き起こす根本原因となっていました。本 API は per-chunk peak を入力にすることで NoiseGate と単位を揃え、この root-cause を解消します。
+
+**将来 follow-up** ([#283] と組): NoiseGate の envelope follower filter を calibration 入力に対して simulate し envelope の 95%ile を取れば margin を 1-2 dB に縮められる可能性があります。
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -83,7 +83,7 @@ livecap-cli devices
 
 マイク入力の dB レベルをリアルタイム表示し、環境ノイズから `--noise-gate-threshold` の推奨値を算出します（Issue #278, #280）。
 
-推奨閾値アルゴリズム: `noise_peak (95パーセンタイル) + 10 dB`。`±5 dB` の「死のゾーン」を避けるため、安全マージン側の保守的な値を推奨します（根拠: livecap-gui PR #294 実測）。
+推奨閾値アルゴリズム: `peak_p95 (per-chunk |x|.max() の 95%ile) + 6 dB`（Issue #291）。NoiseGate の envelope follower (per-sample peak 追跡) と単位を揃えています。`danger_zone` (`floor ± 5 dB`) は RMS-unit の diagnostic で、手動閾値設定時の「死のゾーン」回避指針です。
 
 ### 使用例
 
@@ -115,10 +115,11 @@ Monitoring mic 0... Press Ctrl+C to stop.
     |           |           |           |
     ████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░   -42.3 dB
 
-Noise floor: ~-74.2 dB (25%ile)
-Noise peak:  ~-58.5 dB (95%ile)
-Suggested --noise-gate-threshold: -49 dB
-  (Danger zone: -79 ~ -69 dB — avoid thresholds here)
+Noise floor:    ~-74.2 dB (RMS 25%ile)
+Noise RMS p95:  ~-58.5 dB (RMS 95%ile)
+Peak p95:       ~-47.0 dB (|x|.max() 95%ile, threshold の基準)
+Suggested --noise-gate-threshold: -41 dB (= peak_p95 + 6)
+  (Danger zone: -79 ~ -69 dB — RMS-unit; avoid manually setting thresholds here)
 ```
 
 ### 出力例（`--json`）
@@ -126,10 +127,10 @@ Suggested --noise-gate-threshold: -49 dB
 ```json
 {
   "noise_floor_db": -74.2,
-  "noise_peak_db": -58.5,
-  "suggested_threshold_db": -48.5,
+  "noise_rms_p95_db": -58.5,
+  "peak_p95_db": -47.0,
+  "suggested_threshold_db": -41.0,
   "danger_zone": [-79.2, -69.2],
-  "safe_zone_min_db": -53.5,
   "sample_count": 50,
   "duration_s": 5.0
 }
@@ -320,7 +321,7 @@ livecap-cli transcribe --realtime --mic 0 \
 >
 > - **攻撃的な閾値 (speech peak 付近) を試す場合**: 既定 `--noise-gate-release 100` (PR C で `30 → 100` に変更済み) がほぼすべての状況をカバーします。さらに緩める場合は `150` や `200` を試す。旧挙動 `30` を明示する場合は `--noise-gate-release 30` を指定 ([PR C 検証データ](../benchmarks/noise-gate-ab.md))。
 > - **旧挙動 (PR #281 までの単一閾値 + `-60 dB` soft-mute) を再現したい場合**: `--noise-gate-close-threshold` に `--noise-gate-threshold` と同じ値を渡し、`--noise-gate-floor -60` を指定します。併せて `--noise-gate-release 30` で短い release も再現。
-> - **死のゾーン回避**: 閾値を `noise_floor ± 5 dB` 範囲に設定しないでください。`levels` コマンドの `danger_zone` を確認し、`suggested_threshold_db` を出発点にしてください。
+> - **死のゾーン回避**: `levels` コマンドの `danger_zone` は **RMS-unit diagnostic**（chunk RMS の `noise_floor ± 5 dB`）で、手動で閾値をこの RMS 範囲に設定すると floor の揺らぎで gate がフリッカーします。`suggested_threshold_db` (peak-unit) はこのゾーンと単位が異なるため直接比較できませんが、出発点として安全に使えます。
 
 ---
 

--- a/docs/reference/livecap-gui-realtime-analysis.md
+++ b/docs/reference/livecap-gui-realtime-analysis.md
@@ -385,6 +385,8 @@ if self.noise_gate:
     processed_data = self.noise_gate.process(flat_data)
 ```
 
+> **GUI 較正キャリブレーション** (issue [#291]): GUI 側で独自に閾値を算出している場合は、`analyze_noise_samples(rms_db_list, peak_db_list)` (新 API; per-chunk RMS と peak を両方渡す) に委譲すべきです。これにより NoiseGate の envelope follower と単位が揃い、無音時 hallucination の root-cause が解消されます。`AudioLevelWorker` 等で per-chunk RMS と一緒に `|x|.max()` を emit すれば本 API を直接呼べます。
+
 ---
 
 ## 4. livecap-cli への適用方針

--- a/livecap_cli/audio/__init__.py
+++ b/livecap_cli/audio/__init__.py
@@ -1,6 +1,11 @@
 """Audio processing utilities."""
 
-from .analysis import NoiseAnalysis, analyze_noise_samples
+from .analysis import PEAK_SAFETY_MARGIN_DB, NoiseAnalysis, analyze_noise_samples
 from .noise_gate import NoiseGate
 
-__all__ = ["NoiseAnalysis", "NoiseGate", "analyze_noise_samples"]
+__all__ = [
+    "PEAK_SAFETY_MARGIN_DB",
+    "NoiseAnalysis",
+    "NoiseGate",
+    "analyze_noise_samples",
+]

--- a/livecap_cli/audio/analysis.py
+++ b/livecap_cli/audio/analysis.py
@@ -2,6 +2,19 @@
 
 録音したノイズサンプル列から推奨閾値・危険ゾーンを算出する純関数群。
 CLI ``levels`` コマンドおよび GUI キャリブレーション UI 双方から再利用される。
+
+NoiseGate (``livecap_cli/audio/noise_gate.py``) の判定は
+**per-sample envelope follower** (実 peak 追跡) で行われるため、calibration
+側も **per-chunk peak (|x|.max())** を入力にして単位を揃える。
+``samples_db`` (chunk RMS) は noise floor / RMS p95 の diagnostic としてのみ
+使用し、``suggested_threshold_db`` は ``peak_p95 + PEAK_SAFETY_MARGIN_DB``
+で求める。
+
+経緯 (livecap-gui#331 / livecap-cli#291): 旧実装は chunk RMS p95 + 10 dB を
+推奨値としており、White noise の crest factor ≈ 11 dB が偶然 ``+10`` で
+吸収されていただけだった。impulsive noise (キーボード/呼吸/breath bursts)
+では crest factor が大きくなり threshold が peak の下に潜り、envelope
+follower が瞬間超え → 無音時 hallucination を引き起こしていた。
 """
 
 from __future__ import annotations
@@ -11,59 +24,99 @@ from typing import Sequence
 
 import numpy as np
 
+PEAK_SAFETY_MARGIN_DB = 6.0
+"""``suggested_threshold_db = peak_p95_db + PEAK_SAFETY_MARGIN_DB``。
+
+``+6 dB`` は NoiseGate 既定 (``attack_ms=0.5``, ``release_ms=100``,
+``sample_rate=16000``) に対する実測ベースのマージン。``attack_ms`` を大幅に
+短くすると envelope の peak 追従が鋭くなるため margin の見直しが必要。
+
+将来 follow-up (#283 と組で別 issue 化予定): NoiseGate の envelope follower
+filter を calibration 入力に対して simulate し envelope の 95%ile を取れば
+margin を 1-2 dB に縮められる。
+"""
+
 
 @dataclass(frozen=True)
 class NoiseAnalysis:
     """ノイズサンプル分析結果。
 
-    dB 単位のレベルサンプル列からノイズフロア/ピーク/推奨閾値を算出した結果。
+    Attributes:
+        noise_floor_db: chunk RMS の 25%ile (RMS-unit, diagnostic)。
+        noise_rms_p95_db: chunk RMS の 95%ile (RMS-unit, diagnostic)。
+        peak_p95_db: per-chunk ``|x|.max()`` の 95%ile (peak-unit)。
+            ``suggested_threshold_db`` の計算基準。NoiseGate envelope
+            follower の単位と一致する。
+        suggested_threshold_db: ``peak_p95_db + PEAK_SAFETY_MARGIN_DB``。
+            NoiseGate の ``threshold_db`` にそのまま渡せる値。
+        danger_zone: ``(noise_floor_db - 5, noise_floor_db + 5)``。
+            **RMS-unit diagnostic**: 手動で閾値をこの RMS 範囲に設定すると
+            floor の揺らぎで gate がフリッカーするため避けるべき領域。
+            ``suggested_threshold_db`` は peak-unit のため直接比較不可。
+        sample_count: 入力サンプル数。
+        duration_s: 録音時間 (秒)。
     """
 
     noise_floor_db: float
-    noise_peak_db: float
+    noise_rms_p95_db: float
+    peak_p95_db: float
     suggested_threshold_db: float
     danger_zone: tuple[float, float]
-    safe_zone_min_db: float
     sample_count: int
     duration_s: float
 
 
 def analyze_noise_samples(
     samples_db: Sequence[float] | np.ndarray,
+    peak_samples_db: Sequence[float] | np.ndarray,
     sample_rate_hz: float = 10.0,
 ) -> NoiseAnalysis:
-    """ノイズ測定サンプル列から推奨閾値と危険ゾーンを計算する。
+    """ノイズ測定サンプル列から推奨閾値を計算する。
+
+    NoiseGate (``livecap_cli/audio/noise_gate.py``) の envelope follower は
+    per-sample ``|x|`` を追跡するため、calibration も per-chunk
+    ``|x|.max()`` を収集して unit を揃える。chunk RMS は noise_floor /
+    noise_rms_p95 の diagnostic としてのみ使う (``suggested_threshold_db``
+    には影響しない)。
 
     Args:
-        samples_db: dB 単位のレベルサンプル (RMS 値を 20*log10 したもの)。
-        sample_rate_hz: サンプル取得レート (duration_s 計算用)。
+        samples_db: chunk RMS の dB 列 (``20*log10(rms(chunk))``)。
+        peak_samples_db: chunk peak の dB 列
+            (``20*log10(|chunk|.max())``)。``len(peak_samples_db) ==
+            len(samples_db)`` でなければならない。
+        sample_rate_hz: chunk 取得レート (``duration_s`` の計算用)。
 
     Returns:
-        NoiseAnalysis: 分析結果 dataclass。
+        NoiseAnalysis: 分析結果 (``suggested_threshold_db`` は peak ベース)。
 
     Raises:
-        ValueError: samples_db が空、または sample_rate_hz が非正値の場合。
-
-    Note:
-        マージン値の根拠は livecap-gui PR #294 実測:
-        - ±5 dB 領域は「死のゾーン」 (gate flicker 多発)
-        - +10 dB 以上が安全マージン
+        ValueError: ``samples_db`` / ``peak_samples_db`` が空、長さ不一致、
+            または ``sample_rate_hz`` が非正値の場合。
     """
     samples = np.asarray(samples_db, dtype=np.float64)
+    peaks = np.asarray(peak_samples_db, dtype=np.float64)
     if samples.size == 0:
         raise ValueError("samples_db must not be empty")
+    if peaks.size == 0:
+        raise ValueError("peak_samples_db must not be empty")
+    if peaks.size != samples.size:
+        raise ValueError(
+            "samples_db and peak_samples_db length mismatch "
+            f"({samples.size} vs {peaks.size})"
+        )
     if sample_rate_hz <= 0:
         raise ValueError("sample_rate_hz must be positive")
 
     noise_floor = float(np.percentile(samples, 25))
-    noise_peak = float(np.percentile(samples, 95))
+    noise_rms_p95 = float(np.percentile(samples, 95))
+    peak_p95 = float(np.percentile(peaks, 95))
 
     return NoiseAnalysis(
         noise_floor_db=noise_floor,
-        noise_peak_db=noise_peak,
-        suggested_threshold_db=noise_peak + 10.0,
+        noise_rms_p95_db=noise_rms_p95,
+        peak_p95_db=peak_p95,
+        suggested_threshold_db=peak_p95 + PEAK_SAFETY_MARGIN_DB,
         danger_zone=(noise_floor - 5.0, noise_floor + 5.0),
-        safe_zone_min_db=noise_peak + 5.0,
         sample_count=int(samples.size),
         duration_s=float(samples.size / sample_rate_hz),
     )

--- a/livecap_cli/cli.py
+++ b/livecap_cli/cli.py
@@ -227,7 +227,8 @@ def cmd_levels(args: argparse.Namespace) -> int:
                     file=sys.stderr,
                 )
 
-            all_levels: list[float] = []
+            all_rms_levels: list[float] = []
+            all_peak_levels: list[float] = []
             start_time = time.monotonic()
             try:
                 while True:
@@ -238,17 +239,20 @@ def cmd_levels(args: argparse.Namespace) -> int:
                     if chunk is None:
                         continue
                     rms = float(np.sqrt(np.mean(chunk**2)))
-                    db = 20 * np.log10(max(rms, 1e-10))
-                    all_levels.append(db)
+                    peak = float(np.max(np.abs(chunk)))
+                    rms_db = 20 * np.log10(max(rms, 1e-10))
+                    peak_db = 20 * np.log10(max(peak, 1e-10))
+                    all_rms_levels.append(rms_db)
+                    all_peak_levels.append(peak_db)
 
                     if not args.json:
                         bar_width = 40
                         pos = int(
-                            max(0, min(bar_width, (db + 60) / 60 * bar_width))
+                            max(0, min(bar_width, (rms_db + 60) / 60 * bar_width))
                         )
                         bar = bar_full * pos + bar_empty * (bar_width - pos)
                         print(
-                            f"\r    {bar}  {db:6.1f} dB",
+                            f"\r    {bar}  {rms_db:6.1f} dB",
                             end="",
                             flush=True,
                             file=sys.stderr,
@@ -256,36 +260,46 @@ def cmd_levels(args: argparse.Namespace) -> int:
             except KeyboardInterrupt:
                 print("", file=sys.stderr)
 
-            if not all_levels:
+            if not all_rms_levels:
                 print("Error: No samples collected.", file=sys.stderr)
                 return 1
 
             elapsed = time.monotonic() - start_time
-            sample_rate_hz = len(all_levels) / max(elapsed, 1e-6)
+            sample_rate_hz = len(all_rms_levels) / max(elapsed, 1e-6)
             analysis = analyze_noise_samples(
-                all_levels, sample_rate_hz=sample_rate_hz
+                all_rms_levels,
+                all_peak_levels,
+                sample_rate_hz=sample_rate_hz,
             )
 
             if args.json:
                 print(json.dumps(asdict(analysis), indent=2))
             else:
                 print(
-                    f"Noise floor: ~{analysis.noise_floor_db:.1f} dB (25%ile)",
+                    f"Noise floor:    ~{analysis.noise_floor_db:.1f} dB "
+                    f"(RMS 25%ile)",
                     file=sys.stderr,
                 )
                 print(
-                    f"Noise peak:  ~{analysis.noise_peak_db:.1f} dB (95%ile)",
+                    f"Noise RMS p95:  ~{analysis.noise_rms_p95_db:.1f} dB "
+                    f"(RMS 95%ile)",
+                    file=sys.stderr,
+                )
+                print(
+                    f"Peak p95:       ~{analysis.peak_p95_db:.1f} dB "
+                    f"(|x|.max() 95%ile, threshold の基準)",
                     file=sys.stderr,
                 )
                 print(
                     f"Suggested --noise-gate-threshold: "
-                    f"{analysis.suggested_threshold_db:.0f} dB",
+                    f"{analysis.suggested_threshold_db:.0f} dB "
+                    f"(= peak_p95 + 6)",
                     file=sys.stderr,
                 )
                 print(
                     f"  (Danger zone: {analysis.danger_zone[0]:.0f} ~ "
                     f"{analysis.danger_zone[1]:.0f} dB {dash} "
-                    "avoid thresholds here)",
+                    "RMS-unit; avoid manually setting thresholds here)",
                     file=sys.stderr,
                 )
                 print(

--- a/livecap_cli/cli.py
+++ b/livecap_cli/cli.py
@@ -194,7 +194,7 @@ def cmd_levels(args: argparse.Namespace) -> int:
         import numpy as np
 
         from livecap_cli import MicrophoneSource
-        from livecap_cli.audio import analyze_noise_samples
+        from livecap_cli.audio import PEAK_SAFETY_MARGIN_DB, analyze_noise_samples
 
         # Windows cp932 等で Unicode バー文字が encode できない環境向け fallback
         stream_encoding = getattr(sys.stderr, "encoding", None) or "utf-8"
@@ -293,7 +293,7 @@ def cmd_levels(args: argparse.Namespace) -> int:
                 print(
                     f"Suggested --noise-gate-threshold: "
                     f"{analysis.suggested_threshold_db:.0f} dB "
-                    f"(= peak_p95 + 6)",
+                    f"(= peak_p95 + {PEAK_SAFETY_MARGIN_DB:g})",
                     file=sys.stderr,
                 )
                 print(

--- a/tests/audio/test_analysis.py
+++ b/tests/audio/test_analysis.py
@@ -7,7 +7,11 @@ from dataclasses import FrozenInstanceError
 import numpy as np
 import pytest
 
-from livecap_cli.audio import NoiseAnalysis, analyze_noise_samples
+from livecap_cli.audio import (
+    PEAK_SAFETY_MARGIN_DB,
+    NoiseAnalysis,
+    analyze_noise_samples,
+)
 
 
 class TestAnalyzeNoiseSamples:
@@ -15,45 +19,114 @@ class TestAnalyzeNoiseSamples:
 
     def test_basic_analysis(self):
         # 100 samples: 75 @ -70 dB (下位25%以下), 25 @ -50 dB (上位25%)
-        samples = [-70.0] * 75 + [-50.0] * 25
-        result = analyze_noise_samples(samples, sample_rate_hz=10.0)
+        rms = [-70.0] * 75 + [-50.0] * 25
+        # peak は意図的に rms と同値 → suggested = peak_p95 + 6 を確認しやすく
+        peaks = list(rms)
+        result = analyze_noise_samples(rms, peaks, sample_rate_hz=10.0)
 
         assert isinstance(result, NoiseAnalysis)
         # 25%ile は下位25%の境界 → -70 dB
         assert result.noise_floor_db == pytest.approx(-70.0, abs=1.0)
         # 95%ile は上位5%の境界 → -50 dB
-        assert result.noise_peak_db == pytest.approx(-50.0, abs=1.0)
-        # suggested = peak + 10
+        assert result.noise_rms_p95_db == pytest.approx(-50.0, abs=1.0)
+        assert result.peak_p95_db == pytest.approx(-50.0, abs=1.0)
+        # suggested = peak_p95 + 6 (PEAK_SAFETY_MARGIN_DB)
         assert result.suggested_threshold_db == pytest.approx(
-            result.noise_peak_db + 10.0
+            result.peak_p95_db + PEAK_SAFETY_MARGIN_DB
         )
-        # danger_zone = (floor - 5, floor + 5)
+        # danger_zone = (floor - 5, floor + 5) (RMS-unit diagnostic)
         assert result.danger_zone[0] == pytest.approx(result.noise_floor_db - 5.0)
         assert result.danger_zone[1] == pytest.approx(result.noise_floor_db + 5.0)
-        # safe_zone = peak + 5
-        assert result.safe_zone_min_db == pytest.approx(result.noise_peak_db + 5.0)
         # metadata
         assert result.sample_count == 100
         assert result.duration_s == pytest.approx(10.0)
 
-    def test_empty_raises(self):
-        with pytest.raises(ValueError, match="empty"):
-            analyze_noise_samples([])
+    def test_empty_samples_db_raises(self):
+        with pytest.raises(ValueError, match="samples_db must not be empty"):
+            analyze_noise_samples([], [-50.0])
+
+    def test_empty_peak_samples_db_raises(self):
+        with pytest.raises(
+            ValueError, match="peak_samples_db must not be empty"
+        ):
+            analyze_noise_samples([-50.0], [])
+
+    def test_length_mismatch_raises(self):
+        with pytest.raises(ValueError, match="length mismatch"):
+            analyze_noise_samples(
+                [-60.0, -55.0, -50.0], [-40.0, -35.0]
+            )
 
     def test_numpy_array_input(self):
-        samples = np.array([-60.0, -55.0, -50.0, -45.0])
-        result = analyze_noise_samples(samples, sample_rate_hz=2.0)
+        rms = np.array([-60.0, -55.0, -50.0, -45.0])
+        peaks = np.array([-50.0, -45.0, -40.0, -35.0])
+        result = analyze_noise_samples(rms, peaks, sample_rate_hz=2.0)
         assert result.sample_count == 4
         assert result.duration_s == pytest.approx(2.0)
+        # peak_p95 of [-50, -45, -40, -35] ≈ -35.x (95th percentile)
+        assert result.peak_p95_db > -40.0
+        assert result.suggested_threshold_db == pytest.approx(
+            result.peak_p95_db + PEAK_SAFETY_MARGIN_DB
+        )
 
     def test_invalid_sample_rate(self):
         with pytest.raises(ValueError, match="positive"):
-            analyze_noise_samples([-50.0], sample_rate_hz=0)
+            analyze_noise_samples([-50.0], [-40.0], sample_rate_hz=0)
         with pytest.raises(ValueError, match="positive"):
-            analyze_noise_samples([-50.0], sample_rate_hz=-1.0)
+            analyze_noise_samples([-50.0], [-40.0], sample_rate_hz=-1.0)
 
     def test_dataclass_is_frozen(self):
         """NoiseAnalysis は frozen dataclass。"""
-        result = analyze_noise_samples([-60.0, -50.0])
+        result = analyze_noise_samples([-60.0, -50.0], [-50.0, -40.0])
         with pytest.raises(FrozenInstanceError):
             result.noise_floor_db = 0.0  # type: ignore[misc]
+
+
+class TestUnitMatch:
+    """新 API が NoiseGate envelope follower と単位を揃えていることの検証。"""
+
+    def test_white_noise_crest_factor(self):
+        """white noise: peak は RMS の ~11 dB 上 (crest factor)。
+        suggested = peak_p95 + 6 が RMS p95 + 10 (旧バグ算法) より上に来る。
+        """
+        # 100 chunk 分の white noise を模擬: RMS -50 dB / peak -39 dB
+        rms = [-50.0] * 100
+        peaks = [-39.0] * 100  # crest factor 11 dB
+        result = analyze_noise_samples(rms, peaks)
+
+        assert result.peak_p95_db == pytest.approx(-39.0, abs=0.1)
+        assert result.suggested_threshold_db == pytest.approx(-33.0, abs=0.1)
+        # 新 suggested (-33) > 旧 suggested (RMS p95 + 10 = -40)
+        old_suggested = result.noise_rms_p95_db + 10.0
+        assert result.suggested_threshold_db > old_suggested + 5.0
+
+    def test_impulsive_noise(self):
+        """impulsive noise (低 RMS / 高 peak): 旧 path が under-margin だった
+        ケースの回帰。"""
+        # 低 RMS (-55 dB) で時々大きな peak (-31 dB) が混じる → crest 24 dB
+        rms = [-55.0] * 80 + [-50.0] * 20
+        peaks = [-45.0] * 80 + [-31.0] * 20  # 20% に大 peak
+        result = analyze_noise_samples(rms, peaks)
+
+        # peak p95 は上位の -31 を拾う
+        assert result.peak_p95_db == pytest.approx(-31.0, abs=1.0)
+        # 旧 suggested (RMS p95 + 10) = ~-40 dB → peak (-31) より大きく低い
+        old_suggested = result.noise_rms_p95_db + 10.0
+        # 新 suggested (= peak_p95 + 6) は旧より大幅に高い
+        assert result.suggested_threshold_db > old_suggested + 10.0
+
+    def test_sine_wave(self):
+        """sine wave: peak = RMS + 3 dB → 新 path が over-margin でない。"""
+        # sine wave の場合 peak = RMS * sqrt(2) → +3.01 dB
+        rms = [-30.0] * 100
+        peaks = [-26.99] * 100  # RMS + 3 dB
+        result = analyze_noise_samples(rms, peaks)
+
+        assert result.peak_p95_db == pytest.approx(-26.99, abs=0.1)
+        # suggested = -26.99 + 6 = -20.99 dB
+        assert result.suggested_threshold_db == pytest.approx(-20.99, abs=0.1)
+        # sine wave への過剰 margin は無い (RMS との差は 9 dB のみ)
+        assert (
+            result.suggested_threshold_db - result.noise_rms_p95_db
+            == pytest.approx(9.0, abs=0.5)
+        )

--- a/tests/audio/test_noise_gate_calibration.py
+++ b/tests/audio/test_noise_gate_calibration.py
@@ -1,0 +1,127 @@
+"""NoiseGate calibration の end-to-end 回帰テスト (issue #291)。
+
+synthetic impulsive noise を ``analyze_noise_samples()`` に通し、
+旧 threshold (chunk RMS p95 + 10 dB) では NoiseGate が頻繁に開く一方で
+新 threshold (peak_p95 + 6 dB) では gate が閉じ続けることを assert する。
+
+これが本 issue #291 の bug を直接 encode する最終防衛線。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from livecap_cli.audio import NoiseGate, analyze_noise_samples
+
+SR = 16000
+CHUNK = 1600  # 100 ms
+
+
+def _synthesize_burst_noise(
+    duration_s: float = 5.0,
+    base_rms: float = 0.0032,  # ~-50 dBFS RMS
+    burst_amp: float = 0.05,  # ~-26 dBFS peak
+    burst_len_samples: int = 30,
+    burst_interval_s: float = 0.5,
+    seed: int = 42,
+) -> np.ndarray:
+    """白色ノイズ底 + 周期的バースト (キーボード/呼吸を模擬)。
+
+    crest factor が大きい (約 24 dB) ため、旧 RMS-based 推奨閾値では
+    envelope が容易に超え、新 peak-based 推奨閾値では超えない。
+    """
+    rng = np.random.default_rng(seed)
+    n = int(duration_s * SR)
+    audio = (rng.standard_normal(n) * base_rms).astype(np.float32)
+    for start in range(0, n, int(burst_interval_s * SR)):
+        end = min(start + burst_len_samples, n)
+        if end > start:
+            sign = rng.choice([-1, 1], size=end - start).astype(np.float32)
+            audio[start:end] += burst_amp * sign
+    return audio
+
+
+def _collect_per_chunk(audio: np.ndarray) -> tuple[list[float], list[float]]:
+    """``cmd_levels`` と同じやり方で per-chunk RMS と peak を dB 列に変換。"""
+    rms_db: list[float] = []
+    peak_db: list[float] = []
+    for i in range(0, len(audio) - CHUNK + 1, CHUNK):
+        c = audio[i : i + CHUNK]
+        rms = float(np.sqrt(np.mean(c**2)))
+        peak = float(np.max(np.abs(c)))
+        rms_db.append(20 * np.log10(max(rms, 1e-10)))
+        peak_db.append(20 * np.log10(max(peak, 1e-10)))
+    return rms_db, peak_db
+
+
+def _frac_gate_open(gate: NoiseGate, audio: np.ndarray) -> float:
+    """hard-mute 既定 (noise_floor_db=-inf) では output==0 ⟺ gate closed。
+
+    入力が至るところ non-zero なら、output が non-zero な比率が
+    そのまま「gate が開いていた sample 比率」になる。
+    """
+    out = gate.process(audio.copy())
+    return float(np.count_nonzero(out)) / len(out)
+
+
+@pytest.fixture(scope="module")
+def burst_noise() -> np.ndarray:
+    return _synthesize_burst_noise()
+
+
+@pytest.fixture(scope="module")
+def analysis(burst_noise: np.ndarray):
+    rms_db, peak_db = _collect_per_chunk(burst_noise)
+    return analyze_noise_samples(rms_db, peak_db)
+
+
+class TestNoiseGateCalibrationRegression:
+    """#291 root cause regression: unit mismatch causing hallucinations."""
+
+    def test_old_threshold_opens_gate_on_impulsive_noise(
+        self, burst_noise: np.ndarray, analysis
+    ) -> None:
+        """旧バグ算法 (RMS p95 + 10 dB) を再現し、gate が開くことを確認。
+
+        これが「無音時 hallucination」の物理的根拠 — envelope が
+        threshold を超えるため。
+        """
+        old_threshold = analysis.noise_rms_p95_db + 10.0
+        gate = NoiseGate(threshold_db=old_threshold)
+        frac_open = _frac_gate_open(gate, burst_noise)
+        assert frac_open > 0.05, (
+            f"旧 threshold ({old_threshold:.1f} dB) で gate が想定通り開いていない "
+            f"(open frac={frac_open:.3f}). 回帰テストの前提が崩れている可能性。"
+        )
+
+    def test_new_threshold_keeps_gate_closed_on_impulsive_noise(
+        self, burst_noise: np.ndarray, analysis
+    ) -> None:
+        """新算法 (peak_p95 + 6 dB) では gate が閉じ続けることを確認。
+
+        本 issue の修正が機能していることの最終確認。
+        """
+        gate = NoiseGate(threshold_db=analysis.suggested_threshold_db)
+        frac_open = _frac_gate_open(gate, burst_noise)
+        assert frac_open < 0.02, (
+            f"新 suggested ({analysis.suggested_threshold_db:.1f} dB) で gate が "
+            f"閉じきっていない (open frac={frac_open:.3f}). margin 不足の可能性。"
+        )
+
+    def test_speech_still_opens_new_threshold(self, analysis) -> None:
+        """正規の speech は新 threshold でも開く (over-margin で死んでいない)。"""
+        speech = (
+            np.random.default_rng(0).standard_normal(SR) * 0.1
+        ).astype(np.float32)
+        gate = NoiseGate(threshold_db=analysis.suggested_threshold_db)
+        frac_open = _frac_gate_open(gate, speech)
+        assert frac_open > 0.9, (
+            f"新 suggested ({analysis.suggested_threshold_db:.1f} dB) で speech が "
+            f"通過していない (open frac={frac_open:.3f}). over-margin の可能性。"
+        )
+
+    def test_new_threshold_is_higher_than_old(self, analysis) -> None:
+        """新 suggested が旧 suggested より上にある (root-cause の方向性)。"""
+        old_suggested = analysis.noise_rms_p95_db + 10.0
+        assert analysis.suggested_threshold_db > old_suggested

--- a/tests/core/cli/test_cli.py
+++ b/tests/core/cli/test_cli.py
@@ -221,25 +221,28 @@ class TestLevelsBehavior:
         assert result == 0
         data = json.loads(captured.out)
 
-        # NoiseAnalysis の全フィールドが存在する
+        # NoiseAnalysis の全フィールドが存在する (issue #291 新 schema)
         expected_fields = {
             "noise_floor_db",
-            "noise_peak_db",
+            "noise_rms_p95_db",
+            "peak_p95_db",
             "suggested_threshold_db",
             "danger_zone",
-            "safe_zone_min_db",
             "sample_count",
             "duration_s",
         }
         assert expected_fields.issubset(set(data.keys()))
+        # 旧 schema の field は削除されている
+        assert "noise_peak_db" not in data
+        assert "safe_zone_min_db" not in data
 
         # 値の整合性
         assert data["sample_count"] > 0
         assert data["duration_s"] > 0
         assert isinstance(data["danger_zone"], list) and len(data["danger_zone"]) == 2
-        # suggested = peak + 10
+        # suggested = peak_p95 + 6 (PEAK_SAFETY_MARGIN_DB)
         assert data["suggested_threshold_db"] == pytest.approx(
-            data["noise_peak_db"] + 10.0
+            data["peak_p95_db"] + 6.0
         )
 
     def test_levels_duration_stops_within_time_limit(


### PR DESCRIPTION
## TL;DR

GUI 報告「NoiseGate を有効にしても無音時に hallucination が出る」の **root cause を修正**します。較正算法 (`analyze_noise_samples`) と判定算法 (`NoiseGate`) の **dB 単位ミスマッチ**を `livecap_cli` 側 canonical API で解消し、 livecap-gui 側に並存する 3 実装 drift を SSOT に集約します。

Closes #291 · Root-cause issue: livecap-gui#331

## なぜ直すのか — 1 図でわかる root cause

```
判定側 (NoiseGate)                  較正側 (analyze_noise_samples) ← BUG
─────────────────────               ───────────────────────────────────
per-sample |x| の envelope          chunk RMS の 95%ile + 10 dB
follower で threshold 判定          を suggested threshold とする
                                    
≒ 「per-sample peak」単位            ≒ 「chunk RMS」単位
                                    
                       ⚠ 単位が違う ⚠

White noise の crest factor ≒ 11 dB が偶然 +10 で吸収されていたが、
impulsive noise (キーボード/呼吸/breath bursts) では crest factor がもっと大きく、
threshold が peak の下に潜って envelope follower が瞬間超え → 無音時 hallucination
```

実測 (livecap-gui#331 synthetic probe):

| 入力 | RMS p95 | peak p95 | 旧 suggested (RMS+10) | 新 suggested (peak+6) |
|---|---|---|---|---|
| -50 dBFS white noise | -49.8 | -38.0 | -39.8 ← envelope 容易に超える | -32.0 ← envelope が確実に下回る |
| -40 dBFS white noise | -39.7 | -27.7 | -29.7 | -21.7 |

## 何をしたか

**Production (3 files)**:
- `livecap_cli/audio/analysis.py` を **per-chunk peak ベース**に置換 (canonical API)
- `livecap_cli/audio/__init__.py` で `PEAK_SAFETY_MARGIN_DB` を export
- `livecap_cli/cli.py` `cmd_levels` を per-chunk RMS + peak の両方収集に移行

**Tests (3 files; 1 new)**:
- `tests/audio/test_analysis.py` を新 API signature に更新 + crest factor / impulsive / sine の検証 3 件追加 (合計 10 件)
- **`tests/audio/test_noise_gate_calibration.py` (新規)**: synthetic impulsive noise を旧 threshold / 新 threshold で実際に `NoiseGate` に通し、旧で gate が開く / 新で閉じ続けることを assert する **end-to-end 回帰テスト**。本 PR の bug 修正を直接 encode する最終防衛線
- `tests/core/cli/test_cli.py` の JSON schema test を新 field 名に更新

**Docs + CHANGELOG**:
- `docs/reference/api.md`, `docs/reference/cli.md`, `docs/reference/livecap-gui-realtime-analysis.md` の `NoiseAnalysis` / JSON / 概念参照を新 schema に更新
- `CHANGELOG.md` `## [Unreleased]` → `### Changed` に **BREAKING** 項目を Before / After / 動機 / API 変更点 / Migration / 検証 / GUI ペア PR / follow-up 構成で追加 (既存 `#283` PR C 形式に倣う)

## pre-1.0 break (Optional=None 旧バグ温存 flag は導入しない)

`CLAUDE.md` / `AGENTS.md` Backward Compatibility Policy:

> Do not add `Optional[T] = None` "legacy mode" flags whose sole purpose is preserving pre-existing bugs.

旧 `noise_peak + 10` (RMS ベース) は **まさにこの policy が禁じる「旧バグ温存 default」** に該当するため、本 PR では:

- ✂ `peak_samples_db` を **required** にし、Optional=None 経路は実装しない
- ✂ CLI `levels` (本リポジトリ内唯一の caller) を**同 PR で peer 移行**
- ✂ `safe_zone_min_db` 削除 (新 `suggested = peak_p95 + 6` と 1 dB 差で意味崩壊)
- ✂ `noise_peak_db` → `noise_rms_p95_db` 改名 (unit を field 名に明示)

## API 変更まとめ (Migration)

```python
# === 旧 ===
rms_db_list = [20*log10(rms(chunk)) for chunk in chunks]
a = analyze_noise_samples(rms_db_list)
gate = NoiseGate(threshold_db=a.suggested_threshold_db)
# a.noise_peak_db, a.safe_zone_min_db を参照していた consumer は移行が必要

# === 新 ===
rms_db_list  = [20*log10(rms(chunk))    for chunk in chunks]
peak_db_list = [20*log10(|chunk|.max()) for chunk in chunks]  # ← 追加収集
a = analyze_noise_samples(rms_db_list, peak_db_list)
gate = NoiseGate(threshold_db=a.suggested_threshold_db)  # 単位が揃って safe
# a.noise_peak_db    -> a.noise_rms_p95_db
# a.safe_zone_min_db -> (削除; suggested_threshold_db を直接使用)
# a.peak_p95_db      -> 新 field; threshold の基準
```

CLI `levels --json` 利用者: フィールド名のみ変更 (内部で peak も収集するため引数変更不要)。

## 単一の回帰テストで bug → fix を encode

`tests/audio/test_noise_gate_calibration.py` の核心:

```python
def test_old_threshold_opens_gate_on_impulsive_noise(burst_noise, analysis):
    """旧バグ算法 (RMS p95 + 10 dB) を再現し、gate が開くことを確認。"""
    gate = NoiseGate(threshold_db=analysis.noise_rms_p95_db + 10.0)
    assert _frac_gate_open(gate, burst_noise) > 0.05  # 旧では破綻

def test_new_threshold_keeps_gate_closed_on_impulsive_noise(burst_noise, analysis):
    """新算法 (peak_p95 + 6 dB) では gate が閉じ続けることを確認。"""
    gate = NoiseGate(threshold_db=analysis.suggested_threshold_db)
    assert _frac_gate_open(gate, burst_noise) < 0.02  # 新では耐える

def test_speech_still_opens_new_threshold(analysis):
    """正規の speech は新 threshold でも開く (over-margin で死んでいないこと)。"""
    speech = np.random.default_rng(0).standard_normal(SR) * 0.1
    gate = NoiseGate(threshold_db=analysis.suggested_threshold_db)
    assert _frac_gate_open(gate, speech) > 0.9
```

**測定方法**: NoiseGate 既定 (hard-mute, `noise_floor_db=-inf`) では `output[i]==0` ⟺ gate closed。よって `np.count_nonzero(out) / len(out)` = gate が開いていたサンプル比率。既存 `test_noise_gate.py` と同じ output 振幅検査スタイル。

## スコープ外 (本 PR では実装しない)

- **livecap-gui 側のペア PR** (`noise_statistics.py` 削除 + 本 API 委譲) → livecap-gui#335 の対の別 issue
- **envelope simulation p95** ベースの margin 1-2 dB 最適化 → `#283` と組で別 issue
- **NoiseGate `release_ms` 再評価** → `#283` で進行中

## Verification

```bash
# 単体
uv run pytest tests/audio/test_analysis.py -v               # 10 件 PASS
uv run pytest tests/audio/test_noise_gate_calibration.py -v # 4 件 PASS (回帰防衛線)
uv run pytest tests/core/cli/test_cli.py -v                 # 13 件 PASS

# 関連 scope full
uv run pytest tests/audio tests/core/cli                    # 55/55 PASS
```

`test_noise_gate_calibration.py` が green であることが本 PR の最終 OK ライン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
