### PR TITLE
fix: PR-B follow-up — async detector bypass + causal best-effort spec (Issue #295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,33 @@ Package renamed from `livecap-core` to `livecap-cli`.
 
 ### Added
 
+#### Fixed: PR-B follow-up — async path bypass + causal best-effort spec (Issue [#295] PR-B follow-up)
+
+- **`StreamTranscriber.transcribe_async()` が transient detector を bypass**
+  していた問題を修正。`feed_audio()` と `transcribe_async()` の pre-VAD
+  処理を `_apply_pre_vad_processing()` 共通 helper に集約し、両 path が
+  必ず NoiseGate → Layer 1 detector → VAD の順で走るよう pin。
+- **`tests/transcription/test_stream.py::TestTransientDetectorWiring`**
+  を追加 (3 cases): sync/async 両 path の detector 起動、両 path の
+  telemetry 完全一致を assert。再発防止層。
+- **`TransientDetector.process()` docstring** に causal / no-lookahead
+  仕様を明文化。`on` mode の chunked output は best-effort upper bound で
+  あり、bit-exact reconstruction ではないことを記載。32 ms lookahead-
+  delay 拡張は別 issue で track。
+- **`tests/audio/test_transient_detector.py::TestStreamingEquivalence::
+  test_on_mode_chunked_is_causal_best_effort`** を追加: telemetry が
+  full / chunked で一致することと、`on` mode で flagged frame があれば
+  energy が入力より低下することを assert (full vs chunked output の
+  bit-exact equality は意図的に検証しない)。
+- **default mode を `off` のまま維持** + ドキュメント整合: Issue #295
+  / docs / CHANGELOG では旧 v3/v4 で「default observe」と記載していた
+  が、PR-B 実装は安全側の `default off` を採用。calibration は
+  `--transient-filter observe` で明示的に opt-in する運用を明記。
+- 既存挙動への影響: なし (default `off` で detector 構築されないため)。
+- Verification: `pytest tests/audio/test_transient_detector.py
+  tests/transcription/test_stream.py tests/integration/non_speech_filter/`
+  → 86 passed, 8 skipped (env-gated).
+
 #### Layer 1: DSP Transient/Applause Detector (Issue [#295] PR-B)
 
 - **新規 `livecap_cli/audio/transient_detector.py`**: 6 DSP feature

--- a/docs/benchmarks/non-speech-filter.md
+++ b/docs/benchmarks/non-speech-filter.md
@@ -309,6 +309,22 @@ are exposed:
 Reject default ON is intentionally out of scope for PR-B; calibration
 follow-up uses the sweep harness below.
 
+#### Streaming semantics (causal, no lookahead)
+
+The detector processes audio frame-by-frame with a residual buffer so
+feature computation stays continuous across chunked feeds. Telemetry
+counters (`frames_processed`, `applause_frames`) therefore match between
+a single full feed and a chunked feed of the same audio.
+
+In `on` mode the masking is **causal**: it can only zero out the part of
+a flagged frame that falls inside the current chunk. Frames that start
+in the residual (i.e. inside audio already returned to the caller in a
+previous call) cannot be retroactively muted. Chunked output is a
+best-effort upper bound on the single-chunk result; the two outputs are
+not bit-identical. A 1-frame lookahead delay would close the gap at the
+cost of +32 ms latency; that enhancement is tracked separately and was
+intentionally deferred to keep PR-B small.
+
 ### CLI surface
 
 ```bash

--- a/docs/benchmarks/non-speech-filter.md
+++ b/docs/benchmarks/non-speech-filter.md
@@ -407,7 +407,7 @@ exact clip will deliver the v4 PR-B AC target.
 
 | PR | What it must achieve against the baseline |
 |---|---|
-| PR-B (Layer 1: DSP transient detector) | Initially `observe`-only; baseline metrics unchanged. With `--transient-filter=on`, `false_asr_trigger_rate` should drop for TenVAD/WebRTC on `applause_*`, `keyboard_taps`, `door_close`, `cough`, while `short_utterance_recall` stays ≥ baseline. |
+| PR-B (Layer 1: DSP transient detector) | Default `--transient-filter=off` so baseline runtime behaviour is unchanged; calibration uses an explicit `--transient-filter=observe` opt-in. With `--transient-filter=on`, `false_asr_trigger_rate` should drop for TenVAD/WebRTC on `applause_*`, `keyboard_taps`, `door_close`, `cough`, while `short_utterance_recall` stays ≥ baseline. |
 | PR-C (Layer 2: VADStateMachine cooldown extension) | Backend-aware: hysteresis only affects Silero / TenVAD; duration-based cooldown affects all three. Must reduce post-applause false triggers without dropping `post_applause_speech`. |
 | PR-A (Layer 3 + 4: Confidence filter + Prompt reset) | Only measurable with a real engine. With `--engine whispers2t`, `non_empty_hallucination_rate` should approach 0 on the negative set; engine call counts for negatives may stay non-zero (Layer 3 is post-engine). |
 

--- a/livecap_cli/audio/transient_detector.py
+++ b/livecap_cli/audio/transient_detector.py
@@ -234,6 +234,26 @@ class TransientDetector:
             :class:`TransientFeatures` whose ``is_applause_like`` is
             ``True`` — features for non-applause frames are *not* returned
             to keep the streaming hot path cheap.
+
+        Streaming semantics — **causal, no lookahead**:
+
+        - Feature computation is **continuous** across calls: a residual
+          buffer keeps the tail samples that did not form a full frame so
+          the next call resumes seamlessly. ``telemetry.frames_processed``
+          and ``telemetry.applause_frames`` therefore match between
+          ``process(full_audio)`` and a chunked feed of the same audio.
+
+        - In ``"on"`` mode masking is **only applied to the samples that
+          belong to the current chunk**. Frames that start in the residual
+          (i.e. inside audio already returned to the caller in a previous
+          call) can no longer be muted retroactively. The output of a
+          chunked feed therefore leaks slightly more energy than the
+          equivalent single-chunk feed; the chunked output is a
+          best-effort upper bound, not a bit-exact reconstruction.
+
+        Adding a 1-frame lookahead delay would close the gap at the cost
+        of +32 ms latency; that enhancement is tracked separately and
+        intentionally out of scope for the PR-B initial deliverable.
         """
         if self.config.mode == "off":  # pragma: no cover - caller should pass None
             return audio, []

--- a/livecap_cli/transcription/stream.py
+++ b/livecap_cli/transcription/stream.py
@@ -346,16 +346,11 @@ class StreamTranscriber:
             セグメント検出時は engine.transcribe() が呼ばれるため
             処理時間はエンジンに依存する（数十ms〜数百ms）。
         """
-        # ノイズゲート（VAD 前処理）
-        if self._noise_gate is not None:
-            audio = self._noise_gate.process(audio)
-
-        # Layer 1: DSP transient detector (#295 PR-B) — observe-mode by
-        # default (passes audio through, only updates telemetry); 'on'
-        # mode zeroes out applause-flagged frames. Events emitted here are
-        # not yet consumed; PR-C (Layer 2 cooldown) will route them.
-        if self._transient_detector is not None:
-            audio, _transient_events = self._transient_detector.process(audio)
+        # Layer 0+1 pre-VAD processing: NoiseGate (#291) then transient
+        # detector (#295 PR-B). Kept in one helper so feed_audio() and
+        # transcribe_async() cannot drift out of sync (the original PR-B
+        # missed the async branch and bypassed the detector entirely).
+        audio = self._apply_pre_vad_processing(audio)
 
         # VAD処理
         segments = self._vad.process_chunk(audio, sample_rate)
@@ -450,6 +445,21 @@ class StreamTranscriber:
             results.append(last)
 
         return results
+
+    def _apply_pre_vad_processing(self, audio: np.ndarray) -> np.ndarray:
+        """Run NoiseGate (#291) + Layer 1 transient detector (#295 PR-B).
+
+        Shared by ``feed_audio`` (sync path) and ``transcribe_async`` so
+        the pre-VAD stack stays a single source of truth. The transient
+        detector returns ``(processed_audio, events)``; events are
+        currently ignored because PR-B ships without the Layer 2 cooldown
+        consumer (that lives in PR-C).
+        """
+        if self._noise_gate is not None:
+            audio = self._noise_gate.process(audio)
+        if self._transient_detector is not None:
+            audio, _events = self._transient_detector.process(audio)
+        return audio
 
     def reset(self) -> None:
         """状態をリセット"""
@@ -867,9 +877,8 @@ class StreamTranscriber:
             TranscriptionResult
         """
         async for chunk in audio_source:
-            # ノイズゲート（VAD 前処理）
-            if self._noise_gate is not None:
-                chunk = self._noise_gate.process(chunk)
+            # Pre-VAD layers (NoiseGate + transient detector).
+            chunk = self._apply_pre_vad_processing(chunk)
 
             # VAD処理は軽いのでメインスレッドで実行
             segments = self._vad.process_chunk(chunk, audio_source.sample_rate)

--- a/tests/audio/test_transient_detector.py
+++ b/tests/audio/test_transient_detector.py
@@ -219,6 +219,58 @@ class TestStreamingEquivalence:
         assert chunked.telemetry.frames_processed == full.telemetry.frames_processed
         assert chunked.telemetry.applause_frames == full.telemetry.applause_frames
 
+    def test_on_mode_chunked_is_causal_best_effort(self) -> None:
+        """``on`` mode masks causally: chunked output leaks energy, but it
+        still reduces energy versus a no-detector baseline.
+
+        The detector docstring guarantees that ``frames_processed`` and
+        ``applause_frames`` telemetry are identical between full and
+        chunked feeds — we assert that. The chunked OUTPUT is explicitly
+        a best-effort upper bound: we only require that any chunked feed
+        whose telemetry flagged at least one frame produces strictly less
+        energy than the original input. Tight numeric bounds are left out
+        because they are brittle against chunk size and source material;
+        the regression we want to catch is "on mode silently stops
+        zeroing anything when chunked".
+        """
+        audio = _synthesize_applause_burst(
+            n_claps=5, inter_clap_ms=150.0, sample_rate=SAMPLE_RATE
+        ).astype(np.float32)
+
+        full = TransientDetector(_config(mode="on"), sample_rate=SAMPLE_RATE)
+        out_full, _ = full.process(audio)
+
+        chunked = TransientDetector(_config(mode="on"), sample_rate=SAMPLE_RATE)
+        chunk_size = SAMPLE_RATE // 10  # 100 ms chunks
+        chunked_pieces: list[np.ndarray] = []
+        for i in range(0, audio.size, chunk_size):
+            piece, _ = chunked.process(audio[i : i + chunk_size])
+            chunked_pieces.append(piece)
+        out_chunked = np.concatenate(chunked_pieces)
+
+        # Telemetry must match — the residual buffer keeps feature
+        # computation continuous across chunks.
+        assert chunked.telemetry.frames_processed == full.telemetry.frames_processed
+        assert chunked.telemetry.applause_frames == full.telemetry.applause_frames
+
+        input_energy = float(np.sum(audio ** 2))
+        full_energy = float(np.sum(out_full ** 2))
+        chunked_energy = float(np.sum(out_chunked ** 2))
+
+        # If the detector flagged anything at all, both modes must end up
+        # with strictly less energy than the unprocessed input.
+        if chunked.telemetry.applause_frames > 0:
+            assert chunked_energy < input_energy, (
+                "on mode chunked output must mute at least the current-chunk "
+                f"portion of every flagged frame (chunked={chunked_energy}, "
+                f"input={input_energy})"
+            )
+
+        # Full-chunk masking always meets or beats chunked masking
+        # because chunked cannot reach back into the previous chunk's
+        # residual area — but the test does not pin a specific ratio.
+        assert full_energy <= chunked_energy + 1e-6
+
     def test_reset_clears_streaming_state(self) -> None:
         audio = _synthesize_applause_burst(
             n_claps=3, sample_rate=SAMPLE_RATE

--- a/tests/transcription/test_stream.py
+++ b/tests/transcription/test_stream.py
@@ -686,3 +686,110 @@ class TestEnergyGate:
         )
         t.close()
         assert not any("EnergyGate dropped" in r.message for r in caplog.records)
+
+
+# ============================================================================
+# Layer 1 transient detector wiring (#295 PR-B follow-up): both feed_audio()
+# and transcribe_async() must route audio through the detector. The initial
+# PR-B landed with transcribe_async() bypassing the detector — these tests
+# pin the contract so the regression cannot return.
+# ============================================================================
+
+
+import asyncio  # noqa: E402
+
+from livecap_cli.audio.transient_detector import (  # noqa: E402
+    TransientDetector,
+    TransientDetectorConfig,
+)
+
+
+class TestTransientDetectorWiring:
+    """Both sync (feed_audio) and async (transcribe_async) paths must call
+    the detector exactly once per audio chunk fed in."""
+
+    @staticmethod
+    def _make_detector() -> TransientDetector:
+        return TransientDetector(
+            TransientDetectorConfig(mode="observe"), sample_rate=16000
+        )
+
+    def test_feed_audio_invokes_transient_detector(self) -> None:
+        engine = MockEngine()
+        vad = MockVADProcessor()
+        detector = self._make_detector()
+        t = StreamTranscriber(
+            engine=engine,
+            vad_processor=vad,
+            transient_detector=detector,
+            engine_min_rms_dbfs=float("-inf"),
+        )
+        for _ in range(3):
+            t.feed_audio(np.full(1600, 0.05, dtype=np.float32), sample_rate=16000)
+        t.close()
+        assert detector.telemetry.audio_chunks_processed == 3
+
+    def test_transcribe_async_invokes_transient_detector(self) -> None:
+        """transcribe_async() must call the detector — original PR-B bypassed it."""
+        engine = MockEngine()
+        vad = MockVADProcessor()
+        detector = self._make_detector()
+        source = MockAudioSource(
+            chunks=[np.full(1600, 0.05, dtype=np.float32) for _ in range(3)],
+            sample_rate=16000,
+        )
+        t = StreamTranscriber(
+            engine=engine,
+            vad_processor=vad,
+            transient_detector=detector,
+            engine_min_rms_dbfs=float("-inf"),
+        )
+
+        async def _drain() -> None:
+            async for _ in t.transcribe_async(source):
+                pass
+
+        asyncio.run(_drain())
+        t.close()
+        assert detector.telemetry.audio_chunks_processed == 3
+
+    def test_sync_and_async_paths_share_pre_vad_processing(self) -> None:
+        """The two paths must produce identical telemetry when fed the same audio."""
+        chunks = [np.full(1600, 0.05, dtype=np.float32) for _ in range(4)]
+
+        sync_detector = self._make_detector()
+        engine_a = MockEngine()
+        vad_a = MockVADProcessor()
+        t_sync = StreamTranscriber(
+            engine=engine_a,
+            vad_processor=vad_a,
+            transient_detector=sync_detector,
+            engine_min_rms_dbfs=float("-inf"),
+        )
+        for c in chunks:
+            t_sync.feed_audio(c, sample_rate=16000)
+        t_sync.close()
+
+        async_detector = self._make_detector()
+        engine_b = MockEngine()
+        vad_b = MockVADProcessor()
+        source = MockAudioSource(chunks=list(chunks), sample_rate=16000)
+        t_async = StreamTranscriber(
+            engine=engine_b,
+            vad_processor=vad_b,
+            transient_detector=async_detector,
+            engine_min_rms_dbfs=float("-inf"),
+        )
+
+        async def _drain() -> None:
+            async for _ in t_async.transcribe_async(source):
+                pass
+
+        asyncio.run(_drain())
+        t_async.close()
+
+        sync_tel = sync_detector.telemetry
+        async_tel = async_detector.telemetry
+        assert sync_tel.audio_chunks_processed == async_tel.audio_chunks_processed
+        assert sync_tel.frames_processed == async_tel.frames_processed
+        assert sync_tel.applause_frames == async_tel.applause_frames


### PR DESCRIPTION
## Summary
- Issue #295 / PR #300 codex-review follow-up. Fixes the HIGH-priority \`transcribe_async()\` detector bypass and pins the on-mode chunked streaming contract as documented "causal, no lookahead".

## Fixes

### 1. transcribe_async() bypass (HIGH)
Original PR-B integrated the detector into \`feed_audio()\` but not \`transcribe_async()\`. Async users got zero detector telemetry / masking. Resolution:

- Extract \`StreamTranscriber._apply_pre_vad_processing()\` private helper that runs NoiseGate → transient detector in order.
- Both \`feed_audio()\` and \`transcribe_async()\` now call the helper; the two paths can no longer drift out of sync.
- New \`tests/transcription/test_stream.py::TestTransientDetectorWiring\` (3 cases) pins the contract.

### 2. On-mode chunked streaming spec (MEDIUM)
Chunked \`on\` mode cannot retroactively mute frames that span a chunk boundary, so a 100 ms-chunked feed leaks more energy than a single-chunk feed. This is a documented causal limitation; a 1-frame lookahead delay (+32 ms latency) would close it and is intentionally tracked as a separate follow-up.

- \`TransientDetector.process()\` docstring spells out the causal / no-lookahead contract.
- \`docs/benchmarks/non-speech-filter.md\` gains a "Streaming semantics" subsection.
- \`tests/audio/test_transient_detector.py::TestStreamingEquivalence::test_on_mode_chunked_is_causal_best_effort\` asserts telemetry equivalence + the "if anything was flagged, on-mode must reduce energy" property without pinning brittle numeric thresholds (per reviewer recommendation).

### 3. Default mode docs alignment
v3/v4 of Issue #295 documented \`--transient-filter default=observe\` but PR-B shipped \`default=off\`. CHANGELOG + Issue v5 are updated to record the safer \`off\` default with "pass \`--transient-filter observe\` when calibrating" guidance. No code change.

## Verification
- \`uv run pytest tests/audio/ tests/integration/non_speech_filter/ tests/integration/vad/ tests/transcription/ tests/core/cli/ tests/audio_sources/\` → **300 passed, 5 skipped (env-gated), 0 failed**.
- TestTransientDetectorWiring (3 cases): sync + async both call detector, telemetry equivalent.
- test_on_mode_chunked_is_causal_best_effort: causal contract verified.

## Out of scope (separate follow-ups)
- Lookahead-delay implementation for perfect chunked masking (separate issue to be filed).
- sherpa-onnx vs sherpa-onnx-core version pin alignment (#298 carry-over, separate dependency PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)