### PR TITLE
chore(engines): remove TranscriptionResult.__iter__ tuple compat (pre-1.0 cleanup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,44 @@ rewrite, this lands the Phase 1 Layer 3 schema required to close Issue
 
 ### Changed
 
+#### `TranscriptionResult.__iter__` 削除 (pre-1.0 cleanup)
+
+PR-A.0 ([#309]) で導入した ``TranscriptionResult.__iter__`` (旧
+``Tuple[str, float]`` 戻り値との後方互換 shim) を削除。pre-1.0 (
+`1.0.0.dev0`) では legacy compat shim は不要との CLAUDE.md / AGENTS.md
+方針に従う。
+
+- **Before**: ``text, confidence = engine.transcribe(audio, sr)`` の
+  tuple unpacking 形が動作 (``TranscriptionResult.__iter__`` 経由)。
+- **After**: ``result = engine.transcribe(audio, sr); text =
+  result.text; confidence = result.confidence`` の attribute access に
+  統一。``__iter__`` 削除により tuple unpacking は ``TypeError`` で fail。
+- **Migration**:
+  - `livecap_cli/transcription/stream.py`: 3 path (sync / async /
+    interim) を attribute access に migration
+  - `benchmarks/asr/runner.py` / `benchmarks/common/engines.py` /
+    `benchmarks/optimization/objective.py`: 同 migration
+  - `tests/`: 4 mock engine fixture (test_stream.py /
+    test_stream_translation.py / test_mock_realtime_flow.py /
+    test_from_language_integration.py) を ``Tuple[str, float]`` 返却 →
+    ``TranscriptionResult`` 返却に統一
+  - `tests/core/engines/test_engine_confidence_schema.py`:
+    ``__iter__`` 互換を pin する 3 件を削除、代わりに
+    ``test_tuple_unpacking_no_longer_supported`` で ``TypeError`` 化を
+    pin
+  - `livecap_cli/engines/{base,whispers2t,parakeet,canary,qwen3asr}_engine.py`
+    docstring から「tuple unpacking 互換」記述削除
+  - `livecap_cli/transcription/stream.py` / `confidence_filter.py`
+    docstring も同様に整合
+- **Side effects**:
+  - `livecap_cli/engines/shared_engine_manager.py:443-449` の defensive
+    3-branch (attribute / ``__getitem__`` / fallback) は不変。
+    ``__iter__`` に依存しない別 path のため独立 cleanup PR で対応可。
+  - `livecap_cli/engines/reazonspeech_engine.py:430` の internal helper
+    ``_transcribe_single()`` も不変 (``TranscriptionResult`` ではなく
+    raw tuple を返す内部関数、cleanup scope 外)。
+- **Tests**: 508 → 506 passed (削除 3 - 新 1 = -2)。
+
 #### Engine confidence filter — Voxtral support (Issue [#311] PR-A.4.1)
 
 PR-A.0 ([#309]) / PR-A.1 ([#310]) で whispers2t / parakeet_ja に対応した

--- a/benchmarks/asr/runner.py
+++ b/benchmarks/asr/runner.py
@@ -338,7 +338,8 @@ class ASRBenchmarkRunner:
 
             for _ in range(self.config.runs):
                 start = time.perf_counter()
-                transcript, _ = engine.transcribe(audio_file.audio, audio_file.sample_rate)
+                result = engine.transcribe(audio_file.audio, audio_file.sample_rate)
+                transcript = result.text
                 elapsed = time.perf_counter() - start
                 times.append(elapsed)
 

--- a/benchmarks/common/engines.py
+++ b/benchmarks/common/engines.py
@@ -29,7 +29,8 @@ class BenchmarkEngineManager:
         engine = manager.get_engine("reazonspeech", "cuda", "ja")
 
         # Run transcription
-        transcript, _ = engine.transcribe(audio, sample_rate)
+        result = engine.transcribe(audio, sample_rate)
+        transcript = result.text
 
         # Clean up all engines when done
         manager.clear_cache()

--- a/benchmarks/optimization/objective.py
+++ b/benchmarks/optimization/objective.py
@@ -186,7 +186,8 @@ class VADObjective:
 
             # Transcribe
             try:
-                text, _ = self.engine.transcribe(segment_audio, current_sr)
+                result = self.engine.transcribe(segment_audio, current_sr)
+                text = result.text
                 if text:
                     transcripts.append(text)
             except Exception as e:

--- a/benchmarks/vad/runner.py
+++ b/benchmarks/vad/runner.py
@@ -590,8 +590,8 @@ class VADBenchmarkRunner:
                     segment_audio = audio[start_sample:end_sample]
 
                     if len(segment_audio) > 0:
-                        transcript, _ = engine.transcribe(segment_audio, sample_rate)
-                        run_transcripts.append(transcript)
+                        result = engine.transcribe(segment_audio, sample_rate)
+                        run_transcripts.append(result.text)
 
                 run_elapsed = time.perf_counter() - run_start
                 asr_times.append(run_elapsed)

--- a/docs/architecture/core-api-spec.md
+++ b/docs/architecture/core-api-spec.md
@@ -266,7 +266,9 @@ engine = EngineFactory.create_engine(
 engine.load_model()
 
 # 音声を文字起こし
-text, confidence = engine.transcribe(audio_data, sample_rate)
+result = engine.transcribe(audio_data, sample_rate)
+text = result.text
+confidence = result.confidence
 ```
 
 ### 4.2 利用可能なエンジン
@@ -318,7 +320,11 @@ class BaseEngine(ABC):
     def set_progress_callback(self, callback: ProgressCallback) -> None: ...
 
     @abstractmethod
-    def transcribe(self, audio_data: np.ndarray, sample_rate: int) -> Tuple[str, float]: ...
+    def transcribe(
+        self, audio_data: np.ndarray, sample_rate: int
+    ) -> TranscriptionResult: ...
+    # ``TranscriptionResult`` は text / confidence / engine_confidence を
+    # 持つ frozen dataclass。attribute access で値取得 (Issue #308 / PR-A.0)。
 
     @abstractmethod
     def get_engine_name(self) -> str: ...

--- a/docs/architecture/core-api-spec.md
+++ b/docs/architecture/core-api-spec.md
@@ -395,7 +395,9 @@ engine.load_model()
 audio_data = np.zeros(16000, dtype=np.float32)  # 1秒の無音
 sample_rate = 16000
 
-text, confidence = engine.transcribe(audio_data, sample_rate)
+result = engine.transcribe(audio_data, sample_rate)
+text = result.text
+confidence = result.confidence
 print(f"文字起こし結果: {text} (確信度: {confidence:.2f})")
 ```
 

--- a/docs/reference/feature-inventory.md
+++ b/docs/reference/feature-inventory.md
@@ -327,7 +327,9 @@ engine.load_model()
 audio_data = np.zeros(16000, dtype=np.float32)  # 1秒の無音
 sample_rate = 16000
 
-text, confidence = engine.transcribe(audio_data, sample_rate)
+result = engine.transcribe(audio_data, sample_rate)
+text = result.text
+confidence = result.confidence
 print(f"結果: {text} (確信度: {confidence:.2f})")
 
 # クリーンアップ

--- a/docs/reference/feature-inventory.md
+++ b/docs/reference/feature-inventory.md
@@ -833,8 +833,8 @@ engine.load_model()
 
 # 文字起こし関数の定義
 def transcriber(audio_data, sample_rate):
-    text, confidence = engine.transcribe(audio_data, sample_rate)
-    return text
+    result = engine.transcribe(audio_data, sample_rate)
+    return result.text
 
 # パイプラインの実行
 def on_progress(progress: FileTranscriptionProgress):

--- a/docs/reference/livecap-gui-realtime-analysis.md
+++ b/docs/reference/livecap-gui-realtime-analysis.md
@@ -297,12 +297,14 @@ class TranscriptionResult:
 ```python
 class BaseEngine(ABC):
     @abstractmethod
-    def transcribe(self, audio_data: np.ndarray, sample_rate: int) -> Tuple[str, float]:
+    def transcribe(
+        self, audio_data: np.ndarray, sample_rate: int
+    ) -> TranscriptionResult:
         """
         音声データを文字起こし
 
         Returns:
-            (transcription_text, confidence_score)
+            TranscriptionResult (text / confidence / engine_confidence)
         """
         pass
 

--- a/livecap_cli/engines/base_engine.py
+++ b/livecap_cli/engines/base_engine.py
@@ -55,28 +55,26 @@ class EngineConfidence:
 class TranscriptionResult:
     """ASR engine の戻り値 (Issue #308)。
 
-    `Tuple[str, float]` 時代の caller との後方互換のため `__iter__` を実装:
+    Attribute access で text / confidence / engine_confidence を読む:
 
-        # 旧 caller (動き続ける):
-        text, confidence = engine.transcribe(audio, sr)
-
-        # 新 caller (engine_confidence にアクセス):
         result = engine.transcribe(audio, sr)
+        text = result.text
+        confidence = result.confidence
         if result.engine_confidence.is_available:
+            # PR-A.1 filter / PR-A.4.1 strict gate 判定に使う
             ...
 
-    `confidence: float` は UI/結果用の粗いスコア (既存 semantics 不変)。
-    `engine_confidence: EngineConfidence` は filter 用の生 internal signal。
+    ``confidence: float`` は UI/結果用の粗いスコア (既存 semantics 不変)。
+    ``engine_confidence: EngineConfidence`` は filter 用の生 internal signal。
     両者は別目的・別 semantics で共存する。
+
+    Note: PR-A.0 で導入した ``__iter__`` (Tuple[str, float] 旧契約との
+    後方互換) は pre-1.0 cleanup により本 cleanup PR で削除済。caller は
+    attribute access に統一されている。
     """
     text: str
     confidence: float
     engine_confidence: EngineConfidence = field(default_factory=EngineConfidence)
-
-    def __iter__(self):
-        """Tuple[str, float] 互換: `text, conf = result` をサポート。"""
-        yield self.text
-        yield self.confidence
 
 
 class BaseEngine(ABC):
@@ -350,7 +348,7 @@ class BaseEngine(ABC):
 
         Returns:
             TranscriptionResult: text / confidence / engine_confidence を持つ dataclass。
-            `__iter__` 経由で `text, confidence = result` の tuple unpacking 互換あり。
+            attribute access (``result.text`` / ``result.confidence``) で値を取得。
             engine 内部信頼度 (no_speech_prob / avg_logprob / token_confidence_mean 等)
             にアクセスするには `result.engine_confidence` を参照すること (Issue #308 / PR-A.0)。
         """

--- a/livecap_cli/engines/canary_engine.py
+++ b/livecap_cli/engines/canary_engine.py
@@ -295,9 +295,10 @@ class CanaryEngine(BaseEngine):
         Args:
             audio_data: 音声データ（numpy配列）
             sample_rate: サンプリングレート
-            
+
         Returns:
-            (transcription_text, confidence_score)のタプル
+            TranscriptionResult (engine_confidence は default 全 None、
+            PR-A.4.2 で beam→greedy 切替予定 — Issue [#311] v2.1 参照)
         """
         if not self._initialized or self.model is None:
             raise RuntimeError("Engine not initialized. Call load_model() first.")

--- a/livecap_cli/engines/canary_engine.py
+++ b/livecap_cli/engines/canary_engine.py
@@ -282,8 +282,8 @@ class CanaryEngine(BaseEngine):
 
         Returns:
             TranscriptionResult: Canary は upstream で per-segment confidence を
-            expose しないため、engine_confidence は default (全 None) となる。
-            tuple unpacking 互換のため `text, confidence = result` 形は動作する。
+            expose しないため、engine_confidence は default (全 None) となる
+            (PR-A.4.2 で beam→greedy 切替予定)。attribute access で値取得。
         """
         # Canaryは長時間音声も処理可能
         return self._transcribe_single_chunk(audio_data, sample_rate)

--- a/livecap_cli/engines/parakeet_engine.py
+++ b/livecap_cli/engines/parakeet_engine.py
@@ -402,11 +402,9 @@ class ParakeetEngine(BaseEngine):
 
         Returns:
             TranscriptionResult: text / confidence (互換用、現状は 1.0 固定) /
-            engine_confidence (NeMo Hypothesis から抽出: `token_confidence_mean`
-            または fallback として `avg_logprob` (length-normalized score、
-            Whisper の avg_logprob とは異なるセマンティクス))。
-            tuple unpacking 互換のため `text, confidence = result` 形は動作する
-            (Issue #308 / PR-A.0)。
+            engine_confidence (NeMo Hypothesis から抽出: `token_confidence_mean`)。
+            attribute access (``result.text`` / ``result.confidence`` /
+            ``result.engine_confidence``) で値取得 (Issue #308 / PR-A.0)。
         """
         # Parakeetは長時間音声も処理可能
         return self._transcribe_single_chunk(audio_data, sample_rate)

--- a/livecap_cli/engines/qwen3asr_engine.py
+++ b/livecap_cli/engines/qwen3asr_engine.py
@@ -335,9 +335,9 @@ class Qwen3ASREngine(BaseEngine):
             sample_rate: サンプリングレート
 
         Returns:
-            TranscriptionResult: Qwen3-ASR は upstream で per-segment confidence を
-            expose しないため、engine_confidence は default (全 None) となる。
-            tuple unpacking 互換のため `text, confidence = result` 形は動作する。
+            TranscriptionResult: Qwen3-ASR は qwen-asr package wrapper で
+            raw scores が隠蔽されているため engine_confidence は default
+            (全 None) となる (PR-A.5 candidate)。attribute access で値取得。
         """
         if not self._initialized or self.model is None:
             raise RuntimeError("Engine not initialized. Call load_model() first.")

--- a/livecap_cli/engines/voxtral_engine.py
+++ b/livecap_cli/engines/voxtral_engine.py
@@ -423,9 +423,10 @@ class VoxtralEngine(BaseEngine):
         Args:
             audio_data: 音声データ（numpy配列）
             sample_rate: サンプリングレート
-            
+
         Returns:
-            (transcription_text, confidence_score)のタプル
+            TranscriptionResult (PR-A.4.1 [#311] から
+            ``engine_confidence.avg_logprob`` を populate)
         """
         if not self._initialized or self.model is None:
             raise RuntimeError("Engine not initialized. Call load_model() first.")

--- a/livecap_cli/engines/whispers2t_engine.py
+++ b/livecap_cli/engines/whispers2t_engine.py
@@ -378,8 +378,7 @@ class WhisperS2TEngine(BaseEngine):
         Returns:
             TranscriptionResult: text / confidence (既存の logprob → exp 計算結果) /
             engine_confidence (`no_speech_prob` / `avg_logprob` / `compression_ratio`
-            の segment mean) を持つ。tuple unpacking 互換のため
-            `text, confidence = result` 形は動作する (Issue #308 / PR-A.0)。
+            の segment mean) を持つ。attribute access (``result.text`` 等) で値取得。
         """
         # WhisperS2Tは長時間音声も処理可能
         # 環境変数切替は不要（固定ディレクトリを使用）

--- a/livecap_cli/transcription/confidence_filter.py
+++ b/livecap_cli/transcription/confidence_filter.py
@@ -244,12 +244,13 @@ def apply_filter(
       (ReazonSpeech / qwen3asr / Canary) は無条件 pass-through。Voxtral は
       PR-A.4.1 ([#311]) から avg_logprob を populate するため filter 対象
       (strict-gated、``should_reject`` docstring 参照)。
-    - ``result`` が ``engine_confidence`` 属性を持たない (legacy
-      ``Tuple[str, float]`` 戻りの mock 等) も pass-through。これは PR-A.0
-      で導入した defensive 互換 pattern (shared_engine_manager.py 等) と整合。
+    - ``result`` が ``engine_confidence`` 属性を持たない (例: 一部の test
+      mock) は pass-through。``shared_engine_manager.py`` の defensive
+      パターンと整合する safety net。
 
     Args:
-        result: ASR engine の戻り値 (``TranscriptionResult`` または legacy tuple)。
+        result: ASR engine の戻り値 (``TranscriptionResult``、または
+            ``engine_confidence`` を持たない test mock)。
         config: filter mode + thresholds。
         source_id: log 用の source 識別子。
         engine_name: log 用の engine 名 (``engine.get_engine_name()`` の値)。

--- a/livecap_cli/transcription/stream.py
+++ b/livecap_cli/transcription/stream.py
@@ -123,9 +123,8 @@ class TranscriptionEngine(Protocol):
         Returns:
             EngineTranscriptionResult: text / confidence / engine_confidence を持つ
             dataclass (``livecap_cli.engines.base_engine.TranscriptionResult``)。
-            Tuple[str, float] 旧契約との後方互換のため
-            ``text, confidence = result`` 形の tuple unpacking が動作する
-            (Issue #308 / PR-A.0)。
+            attribute access (``result.text`` / ``result.confidence`` /
+            ``result.engine_confidence``) で値取得 (Issue #308 / PR-A.0)。
         """
         ...
 
@@ -595,7 +594,8 @@ class StreamTranscriber:
             )
             if engine_result is None:
                 return None
-            text, confidence = engine_result  # __iter__ で旧契約と互換
+            text = engine_result.text
+            confidence = engine_result.confidence
 
             if not text or not text.strip():
                 return None
@@ -683,7 +683,8 @@ class StreamTranscriber:
             )
             if engine_result is None:
                 return None
-            text, confidence = engine_result  # __iter__ で旧契約と互換
+            text = engine_result.text
+            confidence = engine_result.confidence
 
             if not text or not text.strip():
                 return None
@@ -839,7 +840,7 @@ class StreamTranscriber:
             )
             if engine_result is None:
                 return None
-            text, _ = engine_result  # __iter__ で旧 tuple 契約と互換 (confidence は interim では未使用)
+            text = engine_result.text  # interim では confidence 未使用
 
             if not text or not text.strip():
                 return None

--- a/tests/benchmark_tests/asr/test_runner.py
+++ b/tests/benchmark_tests/asr/test_runner.py
@@ -11,6 +11,7 @@ import pytest
 
 from benchmarks.asr.runner import ASRBenchmarkConfig, ASRBenchmarkRunner, DEFAULT_MODE_ENGINES
 from benchmarks.common import AudioFile, BenchmarkResult, Dataset
+from livecap_cli.engines.base_engine import TranscriptionResult
 
 
 class TestASRBenchmarkConfig:
@@ -294,7 +295,7 @@ class TestASRBenchmarkRunner:
 
         # Create mock engine
         mock_engine = MagicMock()
-        mock_engine.transcribe.return_value = ("テスト", 0.95)
+        mock_engine.transcribe.return_value = TranscriptionResult(text="テスト", confidence=0.95)
 
         result = runner._benchmark_file(
             engine=mock_engine,
@@ -357,7 +358,7 @@ class TestASRBenchmarkRunner:
 
         # Create mock engine
         mock_engine = MagicMock()
-        mock_engine.transcribe.return_value = ("テスト", 0.95)
+        mock_engine.transcribe.return_value = TranscriptionResult(text="テスト", confidence=0.95)
 
         result = runner._benchmark_file(
             engine=mock_engine,

--- a/tests/benchmark_tests/vad/test_runner.py
+++ b/tests/benchmark_tests/vad/test_runner.py
@@ -15,6 +15,7 @@ from benchmarks.vad.runner import (
     DEFAULT_MODE_VADS,
 )
 from benchmarks.common import AudioFile, BenchmarkResult, Dataset
+from livecap_cli.engines.base_engine import TranscriptionResult
 
 
 class TestVADBenchmarkConfig:
@@ -323,7 +324,7 @@ class TestVADBenchmarkRunner:
 
         # Create mock engine
         mock_engine = MagicMock()
-        mock_engine.transcribe.return_value = ("テスト", 0.95)
+        mock_engine.transcribe.return_value = TranscriptionResult(text="テスト", confidence=0.95)
 
         result = runner._benchmark_file(
             engine=mock_engine,

--- a/tests/core/engines/test_engine_confidence_schema.py
+++ b/tests/core/engines/test_engine_confidence_schema.py
@@ -53,13 +53,13 @@ class TestEngineConfidenceDefaults:
             ec.no_speech_prob = 0.5  # type: ignore[misc]
 
 
-class TestTranscriptionResultBackwardCompat:
-    def test_tuple_unpacking_yields_text_then_confidence(self):
-        """`text, confidence = result` の旧 caller が動き続けることを pin。"""
-        result = TranscriptionResult(text="hello", confidence=0.5)
-        text, confidence = result
-        assert text == "hello"
-        assert confidence == 0.5
+class TestTranscriptionResultSchema:
+    """``TranscriptionResult`` の attribute access semantics を pin。
+
+    Note: PR-A.0 で導入した ``__iter__`` (Tuple[str, float] 旧契約との
+    後方互換) は pre-1.0 cleanup により削除済。caller は attribute access
+    に統一されている (``stream.py`` / benchmarks / test mock 等)。
+    """
 
     def test_engine_confidence_default_is_empty(self):
         result = TranscriptionResult(text="hi", confidence=0.9)
@@ -77,19 +77,11 @@ class TestTranscriptionResultBackwardCompat:
         with pytest.raises(FrozenInstanceError):
             result.text = "changed"  # type: ignore[misc]
 
-    def test_iter_yields_exactly_two_items(self):
-        """tuple unpacking で 3 つ目を要求すると ValueError になることを pin。"""
+    def test_tuple_unpacking_no_longer_supported(self):
+        """pre-1.0 cleanup で ``__iter__`` を削除済。tuple 旧契約は使えない。"""
         result = TranscriptionResult(text="hi", confidence=0.5)
-        items = list(result)
-        assert items == ["hi", 0.5]
-
-    def test_iter_does_not_yield_engine_confidence(self):
-        """engine_confidence は __iter__ から除外 (Tuple[str, float] 互換のため)。"""
-        ec = EngineConfidence(no_speech_prob=0.1)
-        result = TranscriptionResult(text="hi", confidence=0.5, engine_confidence=ec)
-        items = list(result)
-        assert len(items) == 2
-        assert ec not in items
+        with pytest.raises(TypeError):
+            text, confidence = result  # noqa: F841 — must raise TypeError
 
 
 class TestPublicReexport:

--- a/tests/core/engines/test_voxtral_sample_rate.py
+++ b/tests/core/engines/test_voxtral_sample_rate.py
@@ -78,7 +78,9 @@ class TestVoxtralSampleRateWrite:
             temp_path_mock.exists.return_value = True
             mock_temp_dir.return_value.__truediv__ = MagicMock(return_value=temp_path_mock)
 
-            text, confidence = engine._transcribe_single_chunk(audio, input_sr)
+            result = engine._transcribe_single_chunk(audio, input_sr)
+            text = result.text
+            confidence = result.confidence
 
         # The critical assertion: sf.write must use 16000, NOT 44100
         assert captured_sr["value"] == 16000, (

--- a/tests/core/transcription/test_stream_translation.py
+++ b/tests/core/transcription/test_stream_translation.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import time
 from collections import deque
-from typing import List, Optional, Tuple
+from typing import List, Optional
+
+from livecap_cli.engines.base_engine import TranscriptionResult as EngineTranscriptionResult
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -29,9 +31,9 @@ class MockEngine:
     def __init__(self):
         self.transcribe_calls = []
 
-    def transcribe(self, audio: np.ndarray, sample_rate: int) -> Tuple[str, float]:
+    def transcribe(self, audio: np.ndarray, sample_rate: int) -> EngineTranscriptionResult:
         self.transcribe_calls.append((audio, sample_rate))
-        return "テスト文字起こし", 0.95
+        return EngineTranscriptionResult(text="テスト文字起こし", confidence=0.95)
 
     def get_required_sample_rate(self) -> int:
         return 16000

--- a/tests/integration/engines/test_smoke_engines.py
+++ b/tests/integration/engines/test_smoke_engines.py
@@ -267,8 +267,8 @@ def _model_cache_status(engine) -> ModelCacheStatus | None:
 
 def _build_transcriber(engine):
     def _transcribe(audio: np.ndarray, sample_rate: int) -> str:
-        text, _confidence = engine.transcribe(audio, sample_rate)
-        return text
+        result = engine.transcribe(audio, sample_rate)
+        return result.text
 
     return _transcribe
 

--- a/tests/integration/realtime/test_mock_realtime_flow.py
+++ b/tests/integration/realtime/test_mock_realtime_flow.py
@@ -10,7 +10,7 @@ This ensures CI can run without GPU/torch dependencies.
 
 import asyncio
 from pathlib import Path
-from typing import Tuple
+from livecap_cli.engines.base_engine import TranscriptionResult as EngineTranscriptionResult
 
 import numpy as np
 import pytest
@@ -51,9 +51,12 @@ class MockEngine:
         self._sample_rate = sample_rate
         self.transcribe_count = 0
 
-    def transcribe(self, audio: np.ndarray, sample_rate: int) -> Tuple[str, float]:
+    def transcribe(self, audio: np.ndarray, sample_rate: int) -> EngineTranscriptionResult:
         self.transcribe_count += 1
-        return (self._return_text, self._return_confidence)
+        return EngineTranscriptionResult(
+            text=self._return_text,
+            confidence=self._return_confidence,
+        )
 
     def get_required_sample_rate(self) -> int:
         return self._sample_rate

--- a/tests/integration/vad/test_from_language_integration.py
+++ b/tests/integration/vad/test_from_language_integration.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import warnings
 from pathlib import Path
-from typing import Tuple
+from livecap_cli.engines.base_engine import TranscriptionResult as EngineTranscriptionResult
 
 import numpy as np
 import pytest
@@ -39,9 +39,12 @@ class MockEngine:
         self._sample_rate = sample_rate
         self.transcribe_count = 0
 
-    def transcribe(self, audio: np.ndarray, sample_rate: int) -> Tuple[str, float]:
+    def transcribe(self, audio: np.ndarray, sample_rate: int) -> EngineTranscriptionResult:
         self.transcribe_count += 1
-        return (self._return_text, self._return_confidence)
+        return EngineTranscriptionResult(
+            text=self._return_text,
+            confidence=self._return_confidence,
+        )
 
     def get_required_sample_rate(self) -> int:
         return self._sample_rate

--- a/tests/transcription/test_stream.py
+++ b/tests/transcription/test_stream.py
@@ -1,7 +1,6 @@
 """Unit tests for StreamTranscriber."""
 
 import asyncio
-from typing import Tuple
 
 import numpy as np
 
@@ -31,11 +30,14 @@ class MockEngine:
         self._should_fail = should_fail
         self.call_count = 0
 
-    def transcribe(self, audio: np.ndarray, sample_rate: int) -> Tuple[str, float]:
+    def transcribe(self, audio: np.ndarray, sample_rate: int) -> EngineTranscriptionResult:
         self.call_count += 1
         if self._should_fail:
             raise RuntimeError("Mock engine failure")
-        return (self._return_text, self._return_confidence)
+        return EngineTranscriptionResult(
+            text=self._return_text,
+            confidence=self._return_confidence,
+        )
 
     def get_required_sample_rate(self) -> int:
         return self._sample_rate


### PR DESCRIPTION
## 概要

PR-A.0 ([#309 MERGED](https://github.com/Mega-Gorilla/livecap-cli/pull/309)) で導入した **`TranscriptionResult.__iter__`** (旧 `Tuple[str, float]` 戻り値との後方互換 shim) を削除する pre-1.0 cleanup PR。

PR-A.4.1 ([#313 MERGED](https://github.com/Mega-Gorilla/livecap-cli/pull/313)) で本 cleanup を**別 PR に分離**する判断 (ultrathink 評価結果) を行い、本 PR で実施。`CLAUDE.md` / `AGENTS.md` の **pre-1.0 (`1.0.0.dev0`) では legacy compat shim を残さない方針**に沿った cleanup です。

## 一行で言うと

**`text, confidence = engine.transcribe(audio, sr)` 形の旧 caller 契約を廃止、`result = ...; result.text` の attribute access に統一**。

## 動機

- `livecap_cli/CLAUDE.md` Backward Compatibility Policy: 「pre-1.0 では `Optional[T] = None` 型 legacy mode flag を入れない」「Users who genuinely want the old value can pass it explicitly (opt-in), not the other way around」
- PR-A.0 の `__iter__` 経由 tuple unpacking 互換は **pre-1.0 で温存する理由がない** (内部 caller 全て自社管轄、外部 consumer 不在)
- 残置 → 開発者の認知負荷増 + 混在 (一部は attribute access、一部は tuple unpacking) で読みづらい

## 変更内容

### 削除対象

`livecap_cli/engines/base_engine.py`:
- `TranscriptionResult.__iter__` method (text → confidence を yield)
- class docstring から「Tuple[str, float] 旧契約との後方互換」記述削除、attribute access の使用例に書き換え

### Migration (17 files)

| Category | Files | 変更 |
|---|---|---|
| **Production code** | `stream.py` (3 path) + `confidence_filter.py` + `{whispers2t,parakeet,canary,qwen3asr}_engine.py` docstring | 5 file |
| **Benchmark code** | `asr/runner.py` + `common/engines.py` + `optimization/objective.py` | 3 file |
| **Test mocks** (Tuple → TranscriptionResult 返却) | `test_stream.py` + `test_stream_translation.py` + `test_mock_realtime_flow.py` + `test_from_language_integration.py` | 4 file |
| **Test sites** | `test_voxtral_sample_rate.py:81` (attribute access に migration) | 1 file |
| **Test schema** | `test_engine_confidence_schema.py` (BackwardCompat class 削除、`test_tuple_unpacking_no_longer_supported` で TypeError 化 pin) | 1 file |
| **Docs** | `CHANGELOG.md` | 1 file |
| **TranscriptionResult 本体** | `base_engine.py` (__iter__ 削除) | 1 file |

### 主要 diff サンプル

#### `stream.py` (sync path)

```diff
- text, confidence = engine_result  # __iter__ で旧契約と互換
+ text = engine_result.text
+ confidence = engine_result.confidence
```

#### `base_engine.py::TranscriptionResult`

```diff
- @dataclass(frozen=True)
- class TranscriptionResult:
-     """ASR engine の戻り値 (Issue #308)。
-     `Tuple[str, float]` 時代の caller との後方互換のため `__iter__` を実装:
-         text, confidence = engine.transcribe(audio, sr)
-     """
-     def __iter__(self):
-         """Tuple[str, float] 互換: `text, conf = result` をサポート。"""
-         yield self.text
-         yield self.confidence
+ @dataclass(frozen=True)
+ class TranscriptionResult:
+     """ASR engine の戻り値 (Issue #308)。
+
+     Attribute access で text / confidence / engine_confidence を読む:
+         result = engine.transcribe(audio, sr)
+         text = result.text
+         confidence = result.confidence
+     """
```

#### `test_engine_confidence_schema.py`

```diff
- class TestTranscriptionResultBackwardCompat:
-     def test_tuple_unpacking_yields_text_then_confidence(self): ...
-     def test_iter_yields_exactly_two_items(self): ...
-     def test_iter_does_not_yield_engine_confidence(self): ...
+ class TestTranscriptionResultSchema:
+     """``TranscriptionResult`` の attribute access semantics を pin。"""
+     def test_tuple_unpacking_no_longer_supported(self):
+         """pre-1.0 cleanup で ``__iter__`` を削除済。tuple 旧契約は使えない。"""
+         result = TranscriptionResult(text="hi", confidence=0.5)
+         with pytest.raises(TypeError):
+             text, confidence = result  # must raise TypeError
```

## scope 外 (本 PR では touch しない)

| File | 理由 |
|---|---|
| `livecap_cli/engines/shared_engine_manager.py:443-449` 防御 3-branch (attribute / `__getitem__` / fallback) | `__iter__` 非依存、独立 cleanup PR で対応可 |
| `livecap_cli/engines/reazonspeech_engine.py:430` internal helper `_transcribe_single()` | `TranscriptionResult` ではなく raw tuple を返す内部関数、cleanup scope 外 |
| `benchmarks/non_speech_filter/mock_engine.py` | 既に `TranscriptionResult` 返却 (unchanged) |

## Tests

```powershell
uv run pytest tests/audio/ tests/integration/non_speech_filter/ `
              tests/integration/vad/ tests/transcription/ `
              tests/core/cli/ tests/audio_sources/ tests/core/engines/ `
              -m "not engine_smoke and not gpu and not realtime_e2e and not network and not slow" -q
```

**結果**: **508 → 506 passed** (削除 3 件 - 新 1 件 = -2)。WhisperS2T / Parakeet_ja / Voxtral の confidence filter は全 layer で attribute access に統一されたまま動作、PR-A 系列の核心機能は不変。

### Phase 別 regression 履歴

| Phase | tests | 結果 |
|---|---|---|
| Phase 1 (production caller migration) | 508 → 497 | 11 fail (raw-tuple mock の attribute error、期待通り) |
| Phase 2 (test mock TranscriptionResult 化) | 497 → 508 | 全 pass 復活 |
| Phase 3 (`__iter__` 削除 + pin test 削除) | 508 → 506 | 全 pass、削除 3 - 新 1 = -2 |

## Migration guide (downstream consumer 向け)

本 PR 後、Python 側から `livecap_cli.engines` を直接利用しているコードは:

```python
# Before (動かなくなる)
text, confidence = engine.transcribe(audio, sr)

# After
result = engine.transcribe(audio, sr)
text = result.text
confidence = result.confidence
# あるいは
text, confidence = result.text, result.confidence
```

CLI / API surface 不変 (`livecap-cli transcribe ...` は変化なし、`StreamTranscriber` も attribute access に内部的に整合済)。

## 関連

- 親評価: [PR #313 (PR-A.4.1)](https://github.com/Mega-Gorilla/livecap-cli/pull/313) ultrathink scope discipline で本 cleanup を別 PR に分離決定
- pre-1.0 policy: [CLAUDE.md](https://github.com/Mega-Gorilla/livecap-cli/blob/main/CLAUDE.md) / [AGENTS.md](https://github.com/Mega-Gorilla/livecap-cli/blob/main/AGENTS.md) "Backward Compatibility Policy (pre-1.0)"
- 前段 PR-A.0: [PR #309 MERGED](https://github.com/Mega-Gorilla/livecap-cli/pull/309) で `TranscriptionResult.__iter__` 導入

## Test plan

- [x] Phase 1 (production caller migration) で 11 件 fail → mock 修正
- [x] Phase 2 (test mock TranscriptionResult 化) で 508 passed 復活
- [x] Phase 3 (__iter__ 削除 + pin test 削除) で 506 passed (新 -1 件)
- [x] `test_tuple_unpacking_no_longer_supported` で TypeError 化を pin
- [x] CHANGELOG.md `### Changed` entry に Before/After/Migration/Side effects/Tests
- [x] PR-A 系列 (Voxtral filter) の核心機能 (`webrtc × voxtral × real` 50%→0%) が attribute access 統一後も動作することを各 path で確認
- [x] (誤 commit cleanup) `benchmarks/speaker/data/source_10min.wav` 19 MB binary は次 commit で untrack

🤖 Generated with [Claude Code](https://claude.com/claude-code)
