### PR TITLE
cleanup(filter,canary,parakeet): Issue #321 PR #2 — NeMo fallback chain 削除

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,76 @@ rewrite, this lands the Phase 1 Layer 3 schema required to close Issue
 
 ### Changed
 
+#### Engine confidence — Canary / Parakeet NeMo fallback chain cleanup (Issue [#321] PR #2)
+
+`CanaryEngine._configure_decoding_with_confidence` と
+`ParakeetEngine._configure_decoding_with_confidence` から、`token_confidence`
+取得 path (Path 1) が失敗した場合に **token_confidence なしで継続する silent
+degradation を生む fallback chain** を削除して fail-fast 化。加えて
+`ParakeetEngine._transcribe` の `return_hypotheses=True` TypeError silent
+fallback も削除。
+
+PR #320 (qwen3asr) / PR #322 (Canary `**kwargs`) の precedent と整合、
+「framework contract を trust、silent degradation より hard fail」方針を
+NeMo 系 engine にも適用。
+
+##### Before / After
+
+- **Before**:
+  - Canary: Path 1 (greedy + confidence_cfg) → Path 2 (greedy のみ、confidence
+    なし) → Path 3 (argument-less)。Path 1 失敗時に silent fallback、
+    `token_confidence_mean` が None になり confidence filter は pass-through に degrade
+  - Parakeet: Path 1 (Hybrid CTC) → Path 1.5 (Pure RNNT/TDT) → Path 2
+    (strategy-only) → Path 3 (argument-less)。同様に Path 1/1.5 失敗時に
+    silent fallback
+  - `ParakeetEngine._transcribe`: `transcribe(return_hypotheses=True)` が
+    TypeError なら kwarg なしで再 transcribe、`engine_confidence` 全 None
+    で filter が pass-through に degrade
+- **After**:
+  - Canary: Path 1 のみ、bare 呼出 (try/except 削除)。失敗時は NeMo native
+    `TypeError` / `ValueError` 等が propagate
+  - Parakeet: Path 1 (Hybrid model-family dispatch、temporary fallback で
+    Path 1.5 へ) + Path 1.5 (Pure RNNT/TDT primary、bare 呼出)。Path 1.5
+    失敗時は NeMo error が propagate
+  - `ParakeetEngine._transcribe`: bare 呼出、`return_hypotheses=True` 失敗時
+    は TypeError が propagate (`nemo-toolkit>=2.3,<2.5` の supported range で
+    公式安定 API)
+
+##### Migration
+
+- `nemo-toolkit>=2.3,<2.5` (lockfile `2.3.0`) の supported range では既存
+  挙動と完全に同じ (Path 1 / Path 1.5 / `return_hypotheses=True` は常に成功)
+- supported range 外の旧 nemo build を使う user は、Path 1 が拒否された時点で
+  従来の silent fallback ではなく `TypeError`/`KeyError`/`ValueError` 等が
+  直接 raise されるため、具体的な NeMo error message から nemo version を
+  確認する actionable hint を得る
+- Parakeet **Path 1 (Hybrid CTC)** と **Path 1.5 (Pure RNNT/TDT)** は
+  **model-family dispatch** (hybrid vs pure decoder の正規 dispatch) として
+  温存。legacy fallback ではないため reviewer 承認の上で温存
+
+##### Verification (merge gate)
+
+`tests/integration/engines/test_smoke_engines.py::test_token_confidence_populated`
+で実機 GPU verify (RTX 4090 self-hosted runner):
+
+| Case | Expected token_confidence_mean (probe baseline) |
+|---|---|
+| `canary_gpu_en` (LibriSpeech 英語) | > 0.05 (PR-A.4.2 で 0.0724) |
+| `parakeet_gpu_en` (LibriSpeech 英語) | > 0.10 (PR-A.4.3 で 0.2452) |
+| `parakeet_ja_gpu_ja` (jsut 日本語) | > 0.02 (PR-A.0 で 0.0504) |
+
+新 test は `@pytest.mark.engine_smoke` で hosted CI から除外、self-hosted
+GPU runner でのみ実行。失敗時は merge を blocking する design。
+
+##### Out of scope (本 PR では行わない)
+
+- `confidence_filter.py:386` `hasattr(result, "engine_confidence")` guard
+  削除 — **Issue #321 PR #3** で `shared_engine_manager.py` tuple fallback
+  + `TranscriptionEngine` Protocol cleanup とセットで扱う
+- `BaseEngine.__init__` の `**kwargs` swallowing 削除 — 別 issue
+- nemo-toolkit version の pin 化 / 上限拡大 — 別 issue (本 PR では現状の
+  `>=2.3,<2.5` range を contract として扱う)
+
 #### Engine confidence filter — qwen3asr support via wrapper bypass (Issue [#318] PR-A.5.2)
 
 PR-A 系列の **7 engine 対応** を達成、Confidence Filter (Phase 1 Layer 5) を

--- a/livecap_cli/engines/canary_engine.py
+++ b/livecap_cli/engines/canary_engine.py
@@ -322,60 +322,38 @@ class CanaryEngine(BaseEngine):
         logger.info("モデルの設定が完了しました。")
 
     def _configure_decoding_with_confidence(self) -> None:
-        """Decoding strategy + confidence signal を設定 (3 段 fallback)。
+        """Greedy + confidence_cfg で token_confidence_mean を populate する
+        single-path 設定 (Issue #321 PR #2 で fail-fast 化)。
 
-        1. Greedy + confidence_cfg.preserve_token_confidence=True で
-           token_confidence が populate される (本 PR の目的、Phase 1 probe 済)。
-        2. 1 で TypeError/KeyError → Greedy のみ (confidence なし、fail-open)。
-        3. 2 で失敗 → 引数なし呼出し (旧 NeMo API 互換)。
-        いずれも raise しない (model 自体は動作させる)。
+        失敗時は NeMo native error が propagate (silent degradation を避ける、
+        PR #320 / PR #322 の framework contract trust precedent と整合)。
+        旧 Path 2 (greedy のみ) / Path 3 (argument-less) は token_confidence_mean
+        が None になり confidence filter が pass-through に degrade するため
+        削除済。`nemo-toolkit>=2.3,<2.5` の supported range で Path 1 は
+        必ず受領される。
 
-        Parakeet `parakeet_engine.py:296-365` の pattern 流用。
+        実機 verify: LibriSpeech 英語 → token_confidence_mean=0.0724
+        (threshold 0.005 の 14.5x)、PR-A.4.2 で confirmed、Issue #321 PR #2
+        engine_smoke (`test_token_confidence_populated`) で継続 verify。
         """
-        # Path 1: Greedy + confidence_cfg
-        try:
-            decode_cfg = {
-                'strategy': 'greedy',
-                'confidence_cfg': {
-                    'preserve_token_confidence': True,
-                    'preserve_frame_confidence': True,
-                    'exclude_blank': True,
-                    'aggregation': 'mean',
-                },
-                'greedy': {
-                    'preserve_token_confidence': True,
-                    'preserve_frame_confidence': True,
-                },
-            }
-            self.model.change_decoding_strategy(decode_cfg)
-            logger.info(
-                "Canary greedy + token_confidence: enabled "
-                "(filter active, threshold token_conf < 0.005)"
-            )
-            return
-        except (TypeError, KeyError, ValueError, AttributeError) as e:
-            logger.info(
-                f"Canary confidence cfg rejected ({type(e).__name__}: {e}); "
-                "falling back to greedy strategy only (fail-open)."
-            )
-
-        # Path 2: Greedy only (no confidence)
-        try:
-            self.model.change_decoding_strategy({'strategy': 'greedy'})
-            logger.debug("Canary greedy strategy (no confidence, fail-open)")
-            return
-        except (TypeError, KeyError, ValueError) as e:
-            logger.info(
-                f"Canary greedy strategy rejected ({type(e).__name__}); "
-                "falling back to argument-less call."
-            )
-
-        # Path 3: Argument-less (legacy)
-        try:
-            self.model.change_decoding_strategy()
-        except Exception as inner:
-            logger.warning(f"Could not set Canary decoding strategy: {inner}")
-            # デコーディング設定失敗してもモデルは使用可能 (filter は fail-open)
+        decode_cfg = {
+            'strategy': 'greedy',
+            'confidence_cfg': {
+                'preserve_token_confidence': True,
+                'preserve_frame_confidence': True,
+                'exclude_blank': True,
+                'aggregation': 'mean',
+            },
+            'greedy': {
+                'preserve_token_confidence': True,
+                'preserve_frame_confidence': True,
+            },
+        }
+        self.model.change_decoding_strategy(decode_cfg)
+        logger.info(
+            "Canary greedy + token_confidence: enabled "
+            "(filter active, threshold token_conf < 0.005)"
+        )
     
     # ===============================
     # 既存のインターフェース実装

--- a/livecap_cli/engines/parakeet_engine.py
+++ b/livecap_cli/engines/parakeet_engine.py
@@ -309,22 +309,27 @@ class ParakeetEngine(BaseEngine):
         logger.info(f"{self.engine_name} model initialization complete")
 
     def _configure_decoding_with_confidence(self) -> None:
-        """Decoding strategy + confidence signal を設定 (5 段 fallback 設計)。
+        """Decoding strategy + confidence signal を設定 (model-family dispatch、
+        Issue #321 PR #2 で fail-fast 化)。
 
-        1. Hybrid model (parakeet_ja): CTC decoder + greedy_batch + frame_confidence
-           で token_confidence が確実に populate される (PR #309 verify 済)。
-        1.5. Pure RNNT/TDT model (parakeet 英語): preserve_alignments + greedy +
-             confidence_cfg.preserve_token_confidence で TDT decoding 中に
-             token_confidence を populate (PR-A.4.3 / #316 で追加)。NeMo source
-             ``rnnt_decoding.py:280-282`` の「preserve_frame_confidence は
-             preserve_alignments と同時設定必須」制約を満たす形で構成。
-             実機 probe で ``token_confidence_mean = 0.2452`` (LibriSpeech 英語、
-             threshold 0.005 の **49×**) を確認済。
-        2. 1.5 で TypeError/ValueError → RNNT のまま strategy のみ試行
-           (旧 PR-A.0 path、token_confidence は None で fail-open)。
-        3. 2 で失敗 → 引数のみで strategy 指定で再試行。
-        4. 3 で失敗 → 引数なし呼び出し。
-        いずれの fallback でもエラーは raise しない (model 自体は動作させる)。
+        - **Path 1** (Hybrid model 専用): CTC decoder + frame_confidence で
+          ``token_confidence_mean`` populate (PR #309 verify、parakeet_ja で
+          0.0504)。``decoder_type='ctc'`` 切替がうまく activate しない
+          model/config では Path 1.5 にフォールスルー (legacy fallback では
+          なく model-family dispatch)。
+        - **Path 1.5** (Pure RNNT/TDT primary path): preserve_alignments +
+          confidence_cfg で TDT decoding 中の ``token_confidence_mean``
+          populate (PR-A.4.3 / #316、parakeet 英語で 0.2452)。NeMo
+          ``rnnt_decoding.py:280-282`` の「preserve_frame_confidence は
+          preserve_alignments と同時設定必須」制約を満たす。
+
+        失敗時は NeMo native error が propagate (silent degradation を避ける、
+        PR #320 / PR #322 の framework contract trust precedent と整合)。
+        旧 Path 2 (strategy-only fallback) / Path 3 (argument-less 旧 API
+        互換) は token_confidence が None になり confidence filter が
+        pass-through に degrade するため削除済。`nemo-toolkit>=2.3,<2.5`
+        の supported range で Path 1 (hybrid) / Path 1.5 (pure) いずれかが
+        必ず受領される。
         """
         is_hybrid = hasattr(self.model, 'cur_decoder')
 
@@ -365,56 +370,29 @@ class ParakeetEngine(BaseEngine):
         # Path 1.5: Pure RNNT/TDT model (parakeet 英語) — preserve_alignments を
         # 併設して confidence_cfg を有効化。Hybrid CTC と同じ pattern を
         # decoder_type 切替なしで適用 (TDT decoding 自体が confidence をサポート)。
-        try:
-            tdt_cfg = {
-                'strategy': self.decoding_strategy,
+        # 失敗時は NeMo error が propagate (silent degradation を避ける、
+        # Issue #321 PR #2)。
+        tdt_cfg = {
+            'strategy': self.decoding_strategy,
+            'preserve_alignments': True,
+            'greedy': {
                 'preserve_alignments': True,
-                'greedy': {
-                    'preserve_alignments': True,
-                    'preserve_frame_confidence': True,
-                },
-                'confidence_cfg': {
-                    'preserve_frame_confidence': True,
-                    'preserve_token_confidence': True,
-                    'preserve_word_confidence': False,
-                    'exclude_blank': True,
-                    'aggregation': 'mean',
-                },
-            }
-            self.model.change_decoding_strategy(tdt_cfg)
-            logger.info(
-                f"Parakeet RNNT/TDT: confidence_cfg activated "
-                f"(strategy={self.decoding_strategy!r}, frame_confidence ON, "
-                "token_confidence_mean は filter signal として使用可能 [PR-A.4.3])"
-            )
-            return
-        except (TypeError, KeyError, ValueError, AttributeError) as e:
-            logger.info(
-                f"Parakeet RNNT/TDT confidence_cfg rejected ({type(e).__name__}: {e}); "
-                "falling back to strategy-only (token_confidence will be None)."
-            )
-
-        # Path 2: Legacy minimal path (RNNT 単独 model 用、または Path 1.5 失敗時)
-        # 注: Path 1.5 が失敗した場合の fail-open。filter は no-op (engine_confidence
-        # が None で confidence_filter.py は pass-through する)。
-        try:
-            self.model.change_decoding_strategy(
-                {'strategy': self.decoding_strategy}
-            )
-            logger.debug("Parakeet decoding strategy: minimal (RNNT path, no confidence)")
-            return
-        except (TypeError, KeyError, ValueError) as e:
-            logger.info(
-                f"Parakeet minimal strategy rejected ({type(e).__name__}); "
-                "falling back to argument-less call."
-            )
-
-        # Path 3: 引数なし (旧 NeMo API 互換)
-        try:
-            self.model.change_decoding_strategy()
-        except Exception as inner:
-            logger.warning(f"Could not set decoding strategy: {inner}")
-            # デコーディング戦略の設定に失敗してもモデルは使用可能
+                'preserve_frame_confidence': True,
+            },
+            'confidence_cfg': {
+                'preserve_frame_confidence': True,
+                'preserve_token_confidence': True,
+                'preserve_word_confidence': False,
+                'exclude_blank': True,
+                'aggregation': 'mean',
+            },
+        }
+        self.model.change_decoding_strategy(tdt_cfg)
+        logger.info(
+            f"Parakeet RNNT/TDT: confidence_cfg activated "
+            f"(strategy={self.decoding_strategy!r}, frame_confidence ON, "
+            "token_confidence_mean は filter signal として使用可能 [PR-A.4.3])"
+        )
 
     def load_model(self) -> None:
         """モデルをロードする（Windowsパス問題のワークアラウンド付き）"""
@@ -525,27 +503,16 @@ class ParakeetEngine(BaseEngine):
                 sys.stdout = StringIO()
                 
                 try:
-                    # NeMoのtranscribeメソッドを使用（ファイルパスのリストを渡す）
-                    # TDTモデルでは'audio'パラメータを使用。
-                    # PR-A.0 (Issue #308 / codex-review on #309):
-                    # `return_hypotheses=True` を明示しないと NeMo は text string
-                    # を返し、`Hypothesis.token_confidence` 等にアクセスできない。
-                    # 旧 API で当該キーを受け付けない場合は TypeError → fallback。
-                    try:
-                        transcriptions = self.model.transcribe(
-                            audio=[tmp_filename],
-                            batch_size=1,
-                            return_hypotheses=True,
-                        )
-                    except TypeError as e:
-                        logger.info(
-                            "Parakeet model.transcribe(return_hypotheses=True) "
-                            f"rejected ({e}); engine_confidence will be all-None."
-                        )
-                        transcriptions = self.model.transcribe(
-                            audio=[tmp_filename],
-                            batch_size=1,
-                        )
+                    # NeMo `model.transcribe(..., return_hypotheses=True)` で
+                    # ``Hypothesis.token_confidence`` を取得。``nemo-toolkit>=2.3,<2.5``
+                    # の supported range で公式安定 API、失敗時は NeMo error が
+                    # propagate (Issue #321 PR #2 で旧 TypeError silent fallback
+                    # を削除、silent degradation を避ける)。
+                    transcriptions = self.model.transcribe(
+                        audio=[tmp_filename],
+                        batch_size=1,
+                        return_hypotheses=True,
+                    )
                 finally:
                     # 標準出力を元に戻す
                     sys.stdout = old_stdout

--- a/tests/core/engines/test_parakeet_decoding_strategy.py
+++ b/tests/core/engines/test_parakeet_decoding_strategy.py
@@ -1,13 +1,20 @@
-"""Parakeet `_configure_decoding_with_confidence` の挙動 pin (PR #309)。
+"""Parakeet `_configure_decoding_with_confidence` の挙動 pin (PR #309 →
+Issue #321 PR #2 で fail-fast 化)。
 
 Hybrid TDT-CTC model (parakeet_ja) と pure RNNT model (parakeet 英語) で
 decoding strategy 設定が分岐することを実 NeMo なしで verify する。
 
 検証する不変条件:
-1. Hybrid model (cur_decoder 属性あり) では CTC decoder switch が優先実行される
-2. CTC switch が失敗した場合は legacy (RNNT path) に fallback
-3. Non-hybrid model (cur_decoder なし) では CTC switch は試行せず legacy へ
-4. すべての fallback で例外を raise しない
+1. Hybrid model (cur_decoder 属性あり) では Path 1 (CTC decoder switch) が
+   優先実行される
+2. CTC switch が失敗した場合は Path 1.5 (Pure RNNT/TDT、preserve_alignments
+   + confidence_cfg) に **model-family dispatch** で fall through する
+   (Issue #321 PR #2 以降、これが唯一の許される fallback)
+3. Non-hybrid model (cur_decoder なし) では CTC switch を skip し、
+   Path 1.5 を直接試行する
+4. Path 1.5 失敗時は NeMo native error (TypeError/ValueError 等) が
+   propagate する (旧 Path 2 strategy-only / Path 3 argument-less への
+   silent fallback は Issue #321 PR #2 で削除済、silent degradation 回避)
 """
 import importlib
 from unittest.mock import MagicMock

--- a/tests/core/engines/test_parakeet_decoding_strategy.py
+++ b/tests/core/engines/test_parakeet_decoding_strategy.py
@@ -169,45 +169,48 @@ class TestNonHybridModel:
         assert cfg.get('greedy', {}).get('preserve_alignments') is True
         assert cfg.get('greedy', {}).get('preserve_frame_confidence') is True
 
-    def test_non_hybrid_falls_back_to_strategy_only_when_confidence_cfg_rejected(
+    def test_non_hybrid_raises_when_path_1_5_rejected(
         self, fake_engine_with_model
     ):
-        """Path 1.5 が NeMo に rejected された場合、Path 2 (strategy-only) に fail-open。"""
-        call_count = {'n': 0}
+        """Path 1.5 が NeMo に rejected された場合、Issue #321 PR #2 以降は
+        silent fallback ではなく TypeError が propagate する (fail-fast)。
 
-        def side_effect(*args, **kwargs):
-            call_count['n'] += 1
-            # 1 回目 (Path 1.5: confidence_cfg) を拒否、2 回目 (Path 2: strategy-only) は成功
-            if call_count['n'] == 1:
-                raise TypeError("preserve_alignments not supported in this NeMo version")
-            return None
-
+        旧挙動 (Path 2 strategy-only への silent fallback) は token_confidence
+        が None になり confidence filter が pass-through に degrade する
+        silent degradation だったため削除。
+        """
         fake_model = _pure_rnnt_model_mock()
-        fake_model.change_decoding_strategy.side_effect = side_effect
+        fake_model.change_decoding_strategy.side_effect = TypeError(
+            "preserve_alignments not supported in this NeMo version"
+        )
         fake_engine_with_model.model = fake_model
 
-        fake_engine_with_model._configure_decoding_with_confidence()
+        with pytest.raises(TypeError, match="preserve_alignments"):
+            fake_engine_with_model._configure_decoding_with_confidence()
 
-        # Path 1.5 (失敗) + Path 2 (成功) の 2 call
-        assert call_count['n'] == 2
-        # 2 つ目の call は strategy のみで confidence_cfg を含まない (fail-open)
-        second_call = fake_model.change_decoding_strategy.call_args_list[1]
-        legacy_cfg = second_call.args[0]
-        assert legacy_cfg.get('strategy') == fake_engine_with_model.decoding_strategy
-        assert 'confidence_cfg' not in legacy_cfg
+        # Path 1.5 だけが試行され、旧 Path 2/3 への fallback は走らない
+        assert fake_model.change_decoding_strategy.call_count == 1
 
 
-class TestExceptionResilience:
-    """すべての fallback path で例外を raise しないことを pin。"""
+class TestExceptionPropagation:
+    """Path 2/3 削除 (Issue #321 PR #2) に伴い、Path 1/1.5 失敗時は
+    NeMo native error が propagate することを pin (fail-fast)。"""
 
-    def test_all_change_decoding_strategy_calls_failing_does_not_raise(
+    def test_hybrid_path_1_and_path_1_5_both_failing_propagates(
         self, fake_engine_with_model
     ):
-        fake_model = _hybrid_model_mock()
+        """Hybrid model で Path 1 (CTC switch) と Path 1.5 (RNNT/TDT) の両方
+        が失敗した場合、Path 1.5 の TypeError が propagate する。
 
-        # change_decoding_strategy の全 call を失敗させる
+        旧挙動 (Path 2/3 への silent fallback で raise しない) は削除済。
+        """
+        fake_model = _hybrid_model_mock()
         fake_model.change_decoding_strategy.side_effect = TypeError("always fails")
         fake_engine_with_model.model = fake_model
 
-        # 例外を投げずに完走すること (model 自体は動作させるため)
-        fake_engine_with_model._configure_decoding_with_confidence()
+        with pytest.raises(TypeError, match="always fails"):
+            fake_engine_with_model._configure_decoding_with_confidence()
+
+        # Path 1 (decoder_type='ctc') + Path 1.5 (decoder_type なし) の 2 call
+        # 旧 Path 2/3 への fallback は試行しない
+        assert fake_model.change_decoding_strategy.call_count == 2

--- a/tests/core/engines/test_parakeet_return_hypotheses.py
+++ b/tests/core/engines/test_parakeet_return_hypotheses.py
@@ -114,41 +114,37 @@ class TestHypothesisResultPopulatesEngineConfidence:
         assert result.engine_confidence.avg_logprob is None
 
 
-class TestFallbackWhenReturnHypothesesNotSupported:
-    """旧 NeMo API で return_hypotheses kwarg が拒否されたケースの degrade を pin。
+class TestReturnHypothesesNotSupportedPropagates:
+    """Issue #321 PR #2 以降は ``return_hypotheses=True`` が拒否された場合
+    silent fallback ではなく TypeError が propagate する (fail-fast)。
 
-    livecap-cli は対応バージョン範囲が広いため、未対応 API では adapter が
-    silent crash せず engine_confidence 全 None で生存し続ける必要がある。
+    旧挙動 (kwarg なしで再 transcribe、engine_confidence 全 None) は
+    confidence filter が silent に pass-through に degrade する原因だった
+    ため削除。``nemo-toolkit>=2.3,<2.5`` の supported range で
+    ``return_hypotheses=True`` は公式安定 API、TypeError が出る case は
+    user が nemo version を確認すべき hard error。
     """
 
-    def test_typeerror_triggers_fallback_call_without_kwarg(self, fake_engine, caplog):
+    def test_typeerror_propagates_without_fallback(self, fake_engine):
         call_count = {"n": 0}
 
         def transcribe_side_effect(**kwargs):
             call_count["n"] += 1
-            if call_count["n"] == 1:
-                assert kwargs.get("return_hypotheses") is True
-                raise TypeError("unexpected keyword argument 'return_hypotheses'")
-            # Fallback 呼び出しは return_hypotheses なし、文字列リストを返す
-            assert "return_hypotheses" not in kwargs
-            return ["plain text fallback"]
+            assert kwargs.get("return_hypotheses") is True
+            raise TypeError("unexpected keyword argument 'return_hypotheses'")
 
         fake_model = MagicMock()
         fake_model.transcribe.side_effect = transcribe_side_effect
         fake_engine.model = fake_model
 
-        with caplog.at_level(logging.INFO, logger="livecap_cli.engines.parakeet_engine"):
-            result = fake_engine.transcribe(np.zeros(16000, dtype=np.float32), 16000)
+        with pytest.raises(TypeError, match="return_hypotheses"):
+            fake_engine.transcribe(np.zeros(16000, dtype=np.float32), 16000)
 
-        assert call_count["n"] == 2, "TypeError 時は引数なしで再試行されること"
-        assert result.text == "plain text fallback"
-        assert result.engine_confidence.is_available is False, (
-            "Hypothesis 不在なら engine_confidence は全 None で fail-open"
+        # silent fallback (kwarg なしで再 transcribe) は削除済 → 1 回呼出のみ
+        assert call_count["n"] == 1, (
+            "Issue #321 PR #2: return_hypotheses TypeError 時の silent fallback "
+            "は削除、bare 1 回呼出で raise する"
         )
-        assert any(
-            "return_hypotheses=True" in rec.message and "rejected" in rec.message
-            for rec in caplog.records
-        ), "fallback log が出力されること (運用時に気付ける)"
 
 
 class TestStringResultLeavesEngineConfidenceUnpopulated:

--- a/tests/integration/engines/test_smoke_engines.py
+++ b/tests/integration/engines/test_smoke_engines.py
@@ -348,3 +348,76 @@ def test_engine_smoke_with_real_audio(case: EngineSmokeCase, tmp_path: Path, cap
     assert transcript, "Engine returned an empty transcript"
 
     _assert_transcript_matches(transcript, expected_text, case.language, case)
+
+
+# Issue #321 PR #2 merge gate: NeMo fallback chain 削除後、Canary / Parakeet
+# (ja/en) で token_confidence_mean が populate されることを実機 verify。
+# Silent degradation 検出 (Path 2/3 fallback を削除したため、Path 1/1.5 が
+# 失敗するなら hard fail させて token_confidence なしの状態を見落とさない)。
+_CONFIDENCE_POPULATE_CASES = [
+    case for case in CASES if case.engine in ("canary", "parakeet", "parakeet_ja")
+]
+
+
+@pytest.mark.parametrize(
+    "case", _CONFIDENCE_POPULATE_CASES, ids=lambda c: c.id
+)
+def test_token_confidence_populated(case: EngineSmokeCase, tmp_path: Path) -> None:
+    """NeMo `change_decoding_strategy` (Path 1 / Path 1.5) が成功し、
+    `engine_confidence.token_confidence_mean` が populate されることを pin。
+
+    本 test は Issue #321 PR #2 で Canary / Parakeet の fallback chain
+    (Path 2/3 + `return_hypotheses` TypeError fallback) を削除した際の
+    merge gate。populate が落ちると confidence filter が pass-through に
+    degrade するため、実機 GPU で必ず検証する。
+    """
+    _guard_gpu(case)
+
+    audio_path = _prepare_audio(case, tmp_path)
+    engine_options = _build_engine_options(case)
+
+    try:
+        engine = EngineFactory.create_engine(
+            engine_type=case.engine,
+            device=case.device,
+            **engine_options,
+        )
+    except ImportError as exc:
+        _skip_or_fail(f"{case.engine} dependencies are missing: {exc}")
+    except Exception as exc:
+        _skip_or_fail(f"Failed to initialise engine {case.engine}: {exc}")
+
+    try:
+        try:
+            engine.load_model()
+        except Exception as exc:
+            _skip_or_fail(f"Model for {case.engine} is unavailable: {exc}")
+
+        # FileTranscriptionPipeline を介さず engine.transcribe() を直接呼ぶ
+        # (engine_confidence は VAD segment 単位の生 signal を見たいため)。
+        import soundfile as sf
+
+        audio, sr = sf.read(str(audio_path))
+        if audio.ndim > 1:
+            audio = audio.mean(axis=1)
+        result = engine.transcribe(audio.astype(np.float32), sr)
+
+        assert result.engine_confidence is not None, (
+            f"{case.engine}: engine_confidence is None — TranscriptionResult "
+            "の schema が壊れた可能性"
+        )
+        token_conf = result.engine_confidence.token_confidence_mean
+        assert token_conf is not None, (
+            f"{case.engine}: token_confidence_mean not populated. "
+            "Issue #321 PR #2 fallback removal may have caused silent "
+            "degradation — confidence filter は pass-through に degrade する。"
+        )
+        assert token_conf > 0.0, (
+            f"{case.engine}: token_confidence_mean={token_conf} expected > 0.0 "
+            "for real speech audio"
+        )
+    finally:
+        cleanup = getattr(engine, "cleanup", None)
+        if callable(cleanup):
+            cleanup()
+        _cleanup_gpu_memory()

--- a/tests/integration/engines/test_smoke_engines.py
+++ b/tests/integration/engines/test_smoke_engines.py
@@ -354,9 +354,25 @@ def test_engine_smoke_with_real_audio(case: EngineSmokeCase, tmp_path: Path, cap
 # (ja/en) で token_confidence_mean が populate されることを実機 verify。
 # Silent degradation 検出 (Path 2/3 fallback を削除したため、Path 1/1.5 が
 # 失敗するなら hard fail させて token_confidence なしの状態を見落とさない)。
+#
+# **GPU mark**: `PARAM_CASES` と同様に `case.requires_gpu` の場合は
+# `pytest.mark.gpu` を付与、GPU job (`-m "engine_smoke and gpu"`) で確実に
+# 収集されるようにする (codex-review PR #323 HIGH-1 fix)。
 _CONFIDENCE_POPULATE_CASES = [
-    case for case in CASES if case.engine in ("canary", "parakeet", "parakeet_ja")
+    pytest.param(case, marks=pytest.mark.gpu) if case.requires_gpu else pytest.param(case)
+    for case in CASES
+    if case.engine in ("canary", "parakeet", "parakeet_ja")
 ]
+
+# Per-case minimum token_confidence_mean (PR #323 codex-review MEDIUM-2 fix):
+# PR body / CHANGELOG で公約した閾値を assert に落とし込み、merge gate を
+# 数値で保証する。Probe baseline ≧ 2× の安全マージンで threshold 0.005
+# (confidence_filter default) を上回ることを保証。
+_EXPECTED_TOKEN_CONF_MIN = {
+    "canary_gpu_en": 0.05,         # PR-A.4.2 probe baseline 0.0724
+    "parakeet_gpu_en": 0.10,       # PR-A.4.3 probe baseline 0.2452
+    "parakeet_ja_gpu_ja": 0.02,    # PR-A.0 probe baseline 0.0504
+}
 
 
 @pytest.mark.parametrize(
@@ -370,6 +386,10 @@ def test_token_confidence_populated(case: EngineSmokeCase, tmp_path: Path) -> No
     (Path 2/3 + `return_hypotheses` TypeError fallback) を削除した際の
     merge gate。populate が落ちると confidence filter が pass-through に
     degrade するため、実機 GPU で必ず検証する。
+
+    Per-case minimum (`_EXPECTED_TOKEN_CONF_MIN`) を assert で pin し、
+    閾値 0.005 (confidence_filter default) より十分大きい margin で
+    speech 区間が pass することを保証する。
     """
     _guard_gpu(case)
 
@@ -412,10 +432,19 @@ def test_token_confidence_populated(case: EngineSmokeCase, tmp_path: Path) -> No
             "Issue #321 PR #2 fallback removal may have caused silent "
             "degradation — confidence filter は pass-through に degrade する。"
         )
-        assert token_conf > 0.0, (
-            f"{case.engine}: token_confidence_mean={token_conf} expected > 0.0 "
-            "for real speech audio"
-        )
+
+        minimum = _EXPECTED_TOKEN_CONF_MIN.get(case.id)
+        if minimum is None:
+            # 未登録 case の安全網: populate されていれば minimum > 0.0 で OK
+            assert token_conf > 0.0, (
+                f"{case.engine}: token_confidence_mean={token_conf} expected > 0.0"
+            )
+        else:
+            assert token_conf > minimum, (
+                f"{case.id}: token_confidence_mean={token_conf:.4f} <= "
+                f"expected minimum {minimum} (probe baseline と乖離、Path 1/1.5 "
+                "の confidence_cfg が想定通り効いていない可能性)"
+            )
     finally:
         cleanup = getattr(engine, "cleanup", None)
         if callable(cleanup):


### PR DESCRIPTION
## Summary

[Issue #321](https://github.com/Mega-Gorilla/livecap-cli/issues/321) の **PR #2 of 3**。Canary / Parakeet の `_configure_decoding_with_confidence` から **silent degradation を生む fallback chain** を削除して fail-fast 化、Parakeet `_transcribe` の `return_hypotheses=True` TypeError silent fallback も削除。

PR #320 (qwen3asr) / PR #322 (Canary `**kwargs`) で確立した「framework contract を trust、silent degradation より hard fail」方針を NeMo 系 engine に適用。

- **削除**: Canary Path 2/3、Parakeet Path 2/3、Parakeet Path 1.5 の try/except、Parakeet `return_hypotheses=True` TypeError fallback
- **温存**: Parakeet **Path 1 (Hybrid CTC)** と **Path 1.5 (Pure RNNT/TDT)** は **model-family dispatch** で legacy fallback ではない (reviewer 承認済の温存対象)
- **新 merge gate**: GPU engine_smoke で `token_confidence_mean populate` を実機 verify

Refs: Issue #321 (PR #2 of 3)

## ⚠ MERGE GATE: GPU engine_smoke 必須

reviewer guidance に基づき、本 PR の merge 条件は **unit test pass ではなく実機 GPU engine_smoke**:

`tests/integration/engines/test_smoke_engines.py::test_token_confidence_populated` の以下 3 case が **すべて pass** すること:

| Case | Audio | Expected `token_confidence_mean` |
|---|---|---|
| `canary_gpu_en` | LibriSpeech 英語 | > 0.05 (PR-A.4.2 probe で 0.0724) |
| `parakeet_gpu_en` | LibriSpeech 英語 | > 0.10 (PR-A.4.3 probe で 0.2452) |
| `parakeet_ja_gpu_ja` | jsut 日本語 | > 0.02 (PR-A.0 probe で 0.0504) |

self-hosted RTX 4090 runner (linux + windows) で実行、失敗時は merge blocking。

## Why これが cleanup 価値が高いか

reviewer の framing 通り、silent fallback は **「動いているように見えるが filter benefit が消える」最も危険な failure mode**:

- 旧 Path 2/3 が triggered すると `token_confidence_mean` が None になる
- `confidence_filter.py` の fail-open 規約で **pass-through** (= reject なし、全 transcript を通過させる) に degrade
- user は `--confidence-filter on` のつもりでも、実態は **filter 完全無効化**
- log にも明確な warning は出ない (info level の "falling back to ..." のみ)

`nemo-toolkit>=2.3,<2.5` を repo 側で declare している以上、旧 NeMo API 互換 fallback (Path 2/3) を残す根拠は弱い。fail-fast にして NeMo native error (`TypeError: ... unexpected keyword argument 'confidence_cfg'`) を user に伝えるほうが actionable。

## Changes (file-by-file)

### Canary

**`livecap_cli/engines/canary_engine.py::_configure_decoding_with_confidence`** — 旧 3 段 fallback → Path 1 のみ bare 呼出 (~30 行 net 削減)

```python
# Before (3 path chain with silent fallbacks)
def _configure_decoding_with_confidence(self) -> None:
    # Path 1: Greedy + confidence_cfg
    try: ...
    except (TypeError, KeyError, ValueError, AttributeError) as e:
        logger.info("... falling back to greedy strategy only (fail-open).")
    # Path 2: Greedy only (no confidence)  ← silent degradation
    try: ...
    except (TypeError, KeyError, ValueError) as e:
        logger.info("... falling back to argument-less call.")
    # Path 3: Argument-less (legacy)  ← silent degradation
    try: ...
    except Exception as inner:
        logger.warning(f"Could not set Canary decoding strategy: {inner}")

# After (single-path fail-fast)
def _configure_decoding_with_confidence(self) -> None:
    decode_cfg = {...}
    self.model.change_decoding_strategy(decode_cfg)
    logger.info("Canary greedy + token_confidence: enabled ...")
```

### Parakeet

**`livecap_cli/engines/parakeet_engine.py::_configure_decoding_with_confidence`** — 旧 5 段 fallback → Path 1 + Path 1.5 のみ (model-family dispatch、~45 行 net 削減)

```python
# Before (5 path chain, Path 2/3 silent degradation)
# Path 1: Hybrid CTC ← keep (model-family dispatch)
# Path 1.5: Pure RNNT/TDT ← keep but try/except 削除
# Path 2: Legacy minimal (RNNT 単独 / Path 1.5 失敗時) ← DELETE
# Path 3: Argument-less ← DELETE

# After
def _configure_decoding_with_confidence(self) -> None:
    is_hybrid = hasattr(self.model, 'cur_decoder')

    # Path 1: Hybrid model → CTC decoder (model-family dispatch、temporary fallback で Path 1.5 へ)
    if is_hybrid:
        try:
            self.model.change_decoding_strategy(ctc_cfg, decoder_type='ctc')
            return
        except (TypeError, KeyError, ValueError, AttributeError) as e:
            logger.info(f"Parakeet CTC switch rejected ({e}); trying RNNT/TDT path")

    # Path 1.5: Pure RNNT/TDT primary、bare 呼出 (失敗時は raise)
    self.model.change_decoding_strategy(tdt_cfg)
    logger.info("Parakeet RNNT/TDT: confidence_cfg activated ...")
```

**`livecap_cli/engines/parakeet_engine.py::_transcribe`** — `return_hypotheses=True` TypeError silent fallback 削除

```python
# Before
try:
    transcriptions = self.model.transcribe(audio=[...], return_hypotheses=True)
except TypeError as e:
    logger.info(f"... rejected ({e}); engine_confidence will be all-None.")
    transcriptions = self.model.transcribe(audio=[...])  # silent degradation

# After (bare call、失敗時は TypeError が propagate)
transcriptions = self.model.transcribe(audio=[...], return_hypotheses=True)
```

### Tests (新挙動 pin)

旧 silent fallback 挙動を pin していた 3 unit test を新挙動 (TypeError propagate) に rewrite:

- `test_parakeet_decoding_strategy.py::TestNonHybridModel::test_non_hybrid_raises_when_path_1_5_rejected` (旧 `test_non_hybrid_falls_back_to_strategy_only_when_confidence_cfg_rejected`)
- `test_parakeet_decoding_strategy.py::TestExceptionPropagation::test_hybrid_path_1_and_path_1_5_both_failing_propagates` (旧 `TestExceptionResilience::test_all_change_decoding_strategy_calls_failing_does_not_raise`)
- `test_parakeet_return_hypotheses.py::TestReturnHypothesesNotSupportedPropagates::test_typeerror_propagates_without_fallback` (旧 `TestFallbackWhenReturnHypothesesNotSupported::test_typeerror_triggers_fallback_call_without_kwarg`)

新 engine_smoke `test_token_confidence_populated` (3 cases、`@pytest.mark.engine_smoke`) — merge gate。

### CHANGELOG

`[Unreleased] → ### Changed` に Before / After / Migration / Verification 形式で entry 追加。

## Test plan

- [x] **Local regression** (`pytest -m "not engine_smoke and not gpu ..."`): **712 passed**, baseline 維持、退行ゼロ
- [x] **Unit test 更新**: 3 件の旧 fallback 挙動 pin を新 fail-fast 挙動 pin に rewrite
- [ ] **MERGE GATE — GPU engine_smoke** (RTX 4090 self-hosted runner): `test_token_confidence_populated` 3 case 全 pass

## Reviewer 確認済の温存対象

| Item | Why |
|---|---|
| Parakeet **Path 1 (Hybrid CTC)** | hybrid `parakeet_ja` → CTC decoder switch の model-family dispatch、legacy fallback ではない |
| Parakeet **Path 1.5 (Pure RNNT/TDT)** | pure RNNT/TDT (parakeet 英語) の **primary path**、legacy fallback ではない |
| Parakeet Path 1 の `try/except` | Path 1.5 への temporary fall through (model-family dispatch)、Path 2/3 への fallback は削除 |
| `BaseEngine.__init__` の `**kwargs` swallowing | 別 issue (全 engine interface 統一の議論を要する) |

## Migration

- `nemo-toolkit>=2.3,<2.5` (lockfile `2.3.0`) の supported range では既存挙動と完全に同じ
- supported range 外の旧 nemo build を使う user: TypeError 等が直接 raise されるため、明確な NeMo error message から nemo version を確認できる actionable hint を得る

## Out of scope (Issue #321 別 PR で対応)

| Item | 移管先 |
|---|---|
| `confidence_filter.py:386` `hasattr(result, "engine_confidence")` guard 削除 | **PR #3** (`shared_engine_manager.py:441-449` tuple fallback + `TranscriptionEngine` Protocol cleanup とセット) |
| `BaseEngine.__init__` の `**kwargs` swallowing 削除 | 別 issue |
| nemo-toolkit version の pin 化 / 上限拡大 | 別 issue (本 PR では現状 `>=2.3,<2.5` range を contract として扱う) |

## Related

- 親 issue: #321 (全 engine 横断 backward-compat cleanup audit)
- precedent:
  - PR #320 commit `ee1d2c1` (qwen3asr `_transcribe_with_scores` defensive code 削除)
  - PR #322 (Canary `**kwargs` fail-fast) — Issue #321 PR #1
- reviewer guidance (本 PR の merge gate を決定):
  - 「engine_smoke 必須、unit test のみで merge 判断は弱い」
  - 「Parakeet Path 1/1.5 は model-family dispatch (legacy ではない) → 温存」
  - 「error message が「何が壊れたか」分かる必要 → NeMo native error propagate で達成」
  - 「nemo-toolkit `>=2.3,<2.5` の上限側挙動も意識 → lockfile `2.3.0` を smoke verify 基準、上限 verify は別 PR」

🤖 Generated with [Claude Code](https://claude.com/claude-code)
