### PR TITLE
chore(ci,docs): self-hosted GPU runner の timeout + 復旧 runbook 追加 (Issue #321 follow-up)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,8 +19,12 @@ jobs:
       matrix:
         # Include both hosted and self-hosted runners
         os: [ubuntu-latest, [self-hosted, linux], [self-hosted, windows]]
-        
+
     runs-on: ${{ matrix.os }}
+    # GPU/self-hosted job が runner offline で stuck running 状態にならないよう
+    # job-level timeout を設定 (hosted ubuntu-latest は通常 <2 min で完了)。
+    # self-hosted runner 復旧手順は docs/development/self-hosted-runners.md 参照。
+    timeout-minutes: 60
     
     steps:
       - name: Check out repository
@@ -187,6 +191,11 @@ jobs:
         os: [[self-hosted, linux], [self-hosted, windows]]
 
     runs-on: ${{ matrix.os }}
+    # GPU engine_smoke (Canary/Parakeet/Voxtral/Whisper の model load +
+    # transcribe + token_confidence verify) は cold cache 時に最大 20-30 min。
+    # runner offline で stuck running 状態にならないよう 60 min で hard fail。
+    # self-hosted runner 復旧手順は docs/development/self-hosted-runners.md 参照。
+    timeout-minutes: 60
 
     env:
       LIVECAP_ENABLE_GPU_SMOKE: ${{ vars.LIVECAP_ENABLE_GPU_SMOKE }}

--- a/docs/development/self-hosted-runners.md
+++ b/docs/development/self-hosted-runners.md
@@ -1,0 +1,174 @@
+# Self-Hosted Runners 運用 runbook
+
+GPU 必須テスト (engine_smoke、transcription-pipeline) を回す self-hosted GitHub Actions runner の運用手順をまとめる。
+
+## なぜ self-hosted か
+
+GitHub-hosted runner では CUDA GPU が使えないため、以下を self-hosted で実行している:
+
+- `engine-smoke-gpu`: Canary / Parakeet / Voxtral / Whisper 等 GPU engine の transcribe 動作確認 (`tests/integration/engines/test_smoke_engines.py`)
+  - **PR #323 (Issue #321 PR #2) で merge gate 化**: `test_token_confidence_populated` が NeMo fallback chain 削除後の silent degradation を検出
+- `transcription-pipeline` の self-hosted matrix entry: `FileTranscriptionPipeline` の実 GPU pipeline 動作確認
+
+該当 workflow: [`.github/workflows/integration-tests.yml`](../../.github/workflows/integration-tests.yml)
+
+## 現状のセットアップ
+
+| Runner | OS | GPU | 役割 |
+|---|---|---|---|
+| `windows self host runner` | Windows | NVIDIA GeForce RTX 4090 (24GB) | `engine-smoke-gpu (self-hosted, windows)` + `transcription-pipeline (self-hosted, windows)` |
+| Linux runner | (未設定または expired) | RTX 4090 | (将来必要なら) `engine-smoke-gpu (self-hosted, linux)` + `transcription-pipeline (self-hosted, linux)` |
+
+Runner repo 変数:
+
+- `LIVECAP_ENABLE_GPU_SMOKE` = `"1"` (`engine-smoke-gpu` job の `if` 条件、設定済)
+- `LIVECAP_REQUIRE_ENGINE_SMOKE` = `"1"` (skip ではなく failure として扱う)
+
+## 症状 — Runner registration が消えている
+
+GitHub は **long offline (~14 日以上) の runner を自動 unregister** する。再起動しても以下のエラーで listen 開始できなくなる:
+
+```
+√ Connected to GitHub
+Failed to create a session. The runner registration has been deleted
+from the server, please re-configure. Runner registrations are
+automatically deleted for runners that have not connected to the
+service recently.
+"Runner listener exit with terminated error, stop the service, no retry needed."
+"Exiting runner..."
+```
+
+CI 上では以下のように見える:
+
+- PR の `engine-smoke-gpu (self-hosted, linux/windows)` が **永久 pending** のまま
+- 新 push のたびに `cancelled` になる (concurrency cancel)
+- `gh api repos/Mega-Gorilla/livecap-cli/actions/runners` で **`status: "offline"`** または entry なし
+
+## 復旧手順 (Windows runner)
+
+### 0. 確認 — registration の状態を見る
+
+```pwsh
+gh api repos/Mega-Gorilla/livecap-cli/actions/runners
+```
+
+`"status": "offline"` で `version: null` なら、registration は server 側で削除されている (= 復旧手順が必要)。`"status": "online"` なら起動するだけで OK。
+
+### 1. 旧 registration を削除 (config に残骸があれば)
+
+```pwsh
+cd C:\actions-runner
+
+# 既存 config がある場合、まず remove (失敗しても無視可)
+.\config.cmd remove --token <REMOVAL_TOKEN>
+```
+
+`REMOVAL_TOKEN` は以下で取得 (admin 権限の PAT 必要):
+
+```pwsh
+gh api -X POST repos/Mega-Gorilla/livecap-cli/actions/runners/remove-token
+```
+
+または GitHub UI: `Settings → Actions → Runners → 該当 runner → ⋯ → Remove` (UI 経由は自動)。
+
+### 2. 新規 registration token を取得
+
+GitHub UI:
+
+`https://github.com/Mega-Gorilla/livecap-cli/settings/actions/runners/new`
+
+→ "Configure" セクションの `.\config.cmd --url ... --token <TOKEN>` をコピー。token は **1 時間有効**。
+
+CLI でも可 (admin 権限の PAT 必要):
+
+```pwsh
+gh api -X POST repos/Mega-Gorilla/livecap-cli/actions/runners/registration-token
+```
+
+### 3. Configure + 起動
+
+```pwsh
+cd C:\actions-runner
+
+# Configure (token は上記で取得した値、name と labels はお好み)
+.\config.cmd --url https://github.com/Mega-Gorilla/livecap-cli `
+             --token <REGISTRATION_TOKEN> `
+             --name "windows self host runner" `
+             --labels self-hosted,X64,Windows `
+             --work _work `
+             --unattended
+
+# Interactive 起動 (foreground、Ctrl+C で停止)
+.\run.cmd
+```
+
+長時間運用するなら **Windows service 化** がおすすめ:
+
+```pwsh
+# Service として install
+.\svc install
+
+# 起動
+.\svc start
+
+# 状態確認
+.\svc status
+
+# 停止 / 削除
+.\svc stop
+.\svc uninstall
+```
+
+Windows service にすると logon 不要・OS 起動時に auto start。
+
+### 4. CI 上で reflection を確認
+
+新 PR を push するか既存 PR を re-run、`engine-smoke-gpu (self-hosted, windows)` が pending → running → pass に推移すれば成功。
+
+## Linux runner を追加する場合
+
+Linux runner も同様の手順だが、以下が異なる:
+
+- インストーラ: [actions-runner-linux-x64](https://github.com/actions/runner/releases)
+- Service 化: `sudo ./svc.sh install <USER>` → `sudo ./svc.sh start`
+- labels: `self-hosted,X64,Linux`
+
+Workflow 側 (`integration-tests.yml`) の matrix は両方を含む形で記述されているため、Linux runner が registered であれば自動で job が pickup される。
+
+## Timeout (PR #324 [Issue #321 follow-up] で導入)
+
+`integration-tests.yml` の self-hosted job には `timeout-minutes: 60` を設定。
+
+- runner offline で running 状態に到達できない場合: GitHub の queue 経由で eventually cancel される (workflow run cancel policy 依存)
+- runner online で test が hang した場合: 60 min で job-level hard fail、明確な error signal を CI に残す
+
+cold model cache の場合 engine_smoke は 20-30 min かかるため、60 min は十分な margin (実機 verify では 47.90s で完了)。
+
+## 監視 / アラート (提案、未実装)
+
+- `gh api .../actions/runners` を polling して `status: "offline"` を Slack/Discord に通知する scheduled workflow
+- 別の workflow `.github/workflows/verify-self-hosted-windows.yml` を定期実行 (`schedule: cron`) して runner health check
+
+これらは本 issue scope 外、必要なら別 PR で対応。
+
+## Troubleshooting
+
+### `Configure persistent paths` step で permission denied
+
+Windows runner が UAC 環境下にある場合、`C:\LiveCap\Cache\...` への write permission が無いことがある。runner を **administrator として起動** するか、cache root を user-writable な path (例: `%USERPROFILE%\LiveCap\Cache`) に変更する。
+
+### `Failed to copy ffmpeg-bin` (Linux)
+
+runner ホストに `ffmpeg` / `ffprobe` が system install されていれば自動 detect → copy される。`apt-get install ffmpeg` または手動でバイナリを置く (`~/.local/bin/ffmpeg` 等)。
+
+### `Insufficient VRAM` で skip される
+
+`tests/integration/engines/test_smoke_engines.py` の `_guard_gpu` が VRAM 要件 (e.g. Voxtral は 16GB) を check。RTX 4090 (24GB) なら全 engine OK。
+
+## 関連
+
+- 該当 workflow: [`integration-tests.yml`](../../.github/workflows/integration-tests.yml)
+- Runner verify workflow:
+  - [`verify-self-hosted-windows.yml`](../../.github/workflows/verify-self-hosted-windows.yml)
+  - [`verify-self-hosted-linux.yml`](../../.github/workflows/verify-self-hosted-linux.yml)
+- Issue #321 PR #2 ([#323](https://github.com/Mega-Gorilla/livecap-cli/pull/323)) — `engine-smoke-gpu` の merge gate 化、本 doc の動機


### PR DESCRIPTION
## Summary

[PR #323](https://github.com/Mega-Gorilla/livecap-cli/pull/323) (Issue #321 PR #2) merge 中に判明した self-hosted GPU runner の運用問題に対する follow-up。

- **`timeout-minutes: 60`** を `transcription-pipeline` + `engine-smoke-gpu` jobs に追加 — runner が hang した時の明確な hard fail signal
- **`docs/development/self-hosted-runners.md`** 新規作成 — 復旧手順 runbook (registration auto-cleanup 検出 + 再登録 + service 化 + troubleshooting)

機能変更なし、CI yaml + docs のみ。

## Background — PR #323 で判明した問題

PR #323 の merge gate (`test_token_confidence_populated` 3 cases) を実機で verify しようと local runner を起動した時に判明:

```
√ Connected to GitHub
Failed to create a session. The runner registration has been deleted
from the server, please re-configure. Runner registrations are
automatically deleted for runners that have not connected to the
service recently.
```

→ GitHub は **long offline (~14 日以上) の runner を自動 unregister** する。`gh api repos/Mega-Gorilla/livecap-cli/actions/runners` で `"status": "offline"` + `"version": null` を確認、registration が server 側で削除されていた。

復旧手順が docs に無かったため、本 PR で運用 runbook 化。

## Changes

### `.github/workflows/integration-tests.yml`

#### `transcription-pipeline` job (line 16-)

```yaml
runs-on: ${{ matrix.os }}
# GPU/self-hosted job が runner offline で stuck running 状態にならないよう
# job-level timeout を設定 (hosted ubuntu-latest は通常 <2 min で完了)。
# self-hosted runner 復旧手順は docs/development/self-hosted-runners.md 参照。
timeout-minutes: 60
```

#### `engine-smoke-gpu` job (line 182-)

```yaml
runs-on: ${{ matrix.os }}
# GPU engine_smoke (Canary/Parakeet/Voxtral/Whisper の model load +
# transcribe + token_confidence verify) は cold cache 時に最大 20-30 min。
# runner offline で stuck running 状態にならないよう 60 min で hard fail。
# self-hosted runner 復旧手順は docs/development/self-hosted-runners.md 参照。
timeout-minutes: 60
```

**Caveats**:
- `timeout-minutes` は **job execution time** に作用、queue (runner pending) には作用しない
- runner offline で queue overflow → 既存の GitHub cancel policy (24h-72h timeout) に依存
- runner online で test hang した場合の safety net として機能

cold model cache 時の engine_smoke は実測 47.90s (RTX 4090、PR #323 local verify)。60 min は十分な margin。

### `docs/development/self-hosted-runners.md` (新規、~180 行)

運用 runbook:

1. **なぜ self-hosted か** — GPU テストの必要性
2. **現状のセットアップ** — Windows RTX 4090 24GB
3. **症状検出** — registration auto-cleanup の見分け方
   ```pwsh
   gh api repos/Mega-Gorilla/livecap-cli/actions/runners
   # → "status": "offline", "version": null なら registration 削除済
   ```
4. **復旧手順 (Windows)**:
   - 旧 config 削除 (`.\config.cmd remove --token <REMOVAL>`)
   - 新 registration token 取得 (GitHub UI or `gh api -X POST .../registration-token`)
   - `.\config.cmd --url ... --token <TOKEN> --name ... --labels ... --unattended`
   - `.\run.cmd` (foreground) または `.\svc install + .\svc start` (Windows service)
5. **Linux runner 追加手順**
6. **Timeout 設計** — 本 PR で導入した `timeout-minutes: 60` の意図
7. **Troubleshooting** — UAC permission、ffmpeg、VRAM
8. **監視/アラート** — 提案 (未実装、別 PR scope)

## Test plan

- [x] **Workflow yaml syntax**: `timeout-minutes: 60` を 2 箇所に追加、`runs-on` の直後に配置 (GitHub Actions schema 準拠)
- [x] **Docs render**: GitHub markdown 表記、相対 path link が正しく解決すること
- [x] **機能変更なし**: yaml の動作ロジックは不変、docs は新規追加のみ

## Out of scope

- Runner 監視/アラート workflow (scheduled `runner-health-check.yml` 等) — 別 PR で必要なら対応
- Linux runner の新規 setup — user infra 判断
- GitHub-hosted GPU runner への移行 — paid feature、別議論
- Issue #321 PR #3 (API contract cleanup) — 本 PR とは独立

## Related

- 親 issue: [#321](https://github.com/Mega-Gorilla/livecap-cli/issues/321) (backward-compat cleanup audit)
- 動機 PR: [#323](https://github.com/Mega-Gorilla/livecap-cli/pull/323) (Canary/Parakeet NeMo fallback chain cleanup、merge gate verify 中に運用問題判明)
- 関連 workflow:
  - [`integration-tests.yml`](.github/workflows/integration-tests.yml)
  - [`verify-self-hosted-windows.yml`](.github/workflows/verify-self-hosted-windows.yml)
  - [`verify-self-hosted-linux.yml`](.github/workflows/verify-self-hosted-linux.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
