### PR TITLE
feat(audio): Issue #327 — make PEAK_SAFETY_MARGIN_DB user-tunable via CLI --noise-gate-margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,38 @@ Package renamed from `livecap-core` to `livecap-cli`.
 
 ### Added
 
+#### NoiseGate `PEAK_SAFETY_MARGIN_DB` user-tunable (Issue [#327])
+
+`analyze_noise_samples` の `suggested_threshold_db` 計算に
+`peak_safety_margin_db` keyword 引数を追加、CLI `levels` コマンドに
+`--noise-gate-margin <dB>` flag を追加。`engine_min_rms_margin_db` (#292)
+と並列の API 対称性を回復。
+
+- **`analyze_noise_samples(peak_safety_margin_db=...)`** (keyword-only):
+  `suggested_threshold_db = peak_p95_db + peak_safety_margin_db`。
+  default = `PEAK_SAFETY_MARGIN_DB = 6.0`、既存呼び出しは bit-identical。
+- **CLI `levels --noise-gate-margin <dB>`**: user が任意の margin を渡せる。
+  - 高 SNR studio コンデンサーマイク (AT4040、SM7B 等、self-noise <15 dBA):
+    `2` 〜 **負値** (例: `-5` で `suggested = peak_p95 - 5`、`peak_p95 ≈
+    -60 dB` の AT4040 で `-65 dB` が得られる)
+  - 高ノイズ環境 / 低品質 USB マイク: `10` 程度
+- **CLI 出力**: 旧 hardcoded `(= peak_p95 + 6.0)` を user value 反映
+  `(= peak_p95 + {margin})` に変更、user が `--noise-gate-margin -5` を
+  渡した時に正確な値を表示。
+
+scope: `transcribe` には flag 追加しない (現状 auto-calibration なし、
+parse-only effectless flag は anti-pattern。auto-calibration mode は
+別 issue 候補)。
+
+Workflow (既存 `levels → --noise-gate-threshold` 手動 pass を維持):
+
+```pwsh
+# AT4040 等 studio mic
+livecap-cli levels --mic 0 --duration 10 --noise-gate-margin -5 --json
+# → {"suggested_threshold_db": -64.6, ...}
+livecap-cli transcribe --realtime --mic 0 --noise-gate --noise-gate-threshold -64.6
+```
+
 #### Engine confidence signal schema (Issue [#308] PR-A.0 / Phase 1 Layer 3)
 
 - **`EngineConfidence` / `TranscriptionResult` dataclasses** added to

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -567,7 +567,7 @@ with MicrophoneSource() as mic:
 
 ### 閾値決定のガイドライン
 
-環境ノイズに近い閾値（±5 dB の「死のゾーン」）は、ヒステリシスを入れても避けるべきです。推奨値は `levels` コマンドまたは [`analyze_noise_samples()`](#noiseanalysis--analyze_noise_samples) で算出してください（`noise_peak + 10 dB` の保守的マージン）。
+環境ノイズに近い閾値（±5 dB の「死のゾーン」）は、ヒステリシスを入れても避けるべきです。推奨値は `levels` コマンドまたは [`analyze_noise_samples()`](#noiseanalysis--analyze_noise_samples) で算出してください（`peak_p95 + peak_safety_margin_db` の保守的マージン、default `+6 dB`、issue [#291] / [#327]）。studio コンデンサーマイク (AT4040 等) では `--noise-gate-margin -5` 等の負値で更に下げられます ([#327])。
 
 **攻撃的な閾値 (speech peak 付近) での tuning tips**:
 - `close_threshold_db` を下げると hysteresis band が広がり、より安定 (例: open=-20, close=-30)
@@ -579,20 +579,22 @@ with MicrophoneSource() as mic:
 
 `livecap_cli.audio.analysis` — 録音したノイズサンプル列から推奨閾値・危険ゾーンを算出する純関数。CLI `levels` コマンドと GUI キャリブレーション UI から共通 API として使用されます。
 
-`NoiseGate` (`livecap_cli/audio/noise_gate.py`) は **per-sample envelope follower** で判定するため、calibration も **per-chunk peak (`|x|.max()`)** を入力にして単位を揃えます。`samples_db` (chunk RMS) は noise floor / RMS p95 の diagnostic としてのみ使用し、`suggested_threshold_db` は `peak_p95 + PEAK_SAFETY_MARGIN_DB` で求めます (issue [#291])。
+`NoiseGate` (`livecap_cli/audio/noise_gate.py`) は **per-sample envelope follower** で判定するため、calibration も **per-chunk peak (`|x|.max()`)** を入力にして単位を揃えます。`samples_db` (chunk RMS) は noise floor / RMS p95 の diagnostic としてのみ使用し、`suggested_threshold_db` は `peak_p95 + peak_safety_margin_db` で求めます (default `PEAK_SAFETY_MARGIN_DB = 6.0`、issue [#291] / [#327])。`peak_safety_margin_db` keyword 引数で user-tunable、負値も valid (高 SNR studio mic 向け、[#327])。
 
 ### `NoiseAnalysis` dataclass
 
 ```python
-PEAK_SAFETY_MARGIN_DB = 6.0  # module-level 公開
+PEAK_SAFETY_MARGIN_DB = 6.0              # module-level 公開、peak-unit (NoiseGate)
+ENGINE_MIN_RMS_SAFETY_MARGIN_DB = 6.0    # module-level 公開、RMS-unit (#292 EnergyGate)
 
 @dataclass(frozen=True)
 class NoiseAnalysis:
-    noise_floor_db: float          # RMS p25 (RMS-unit, diagnostic)
-    noise_rms_p95_db: float        # RMS p95 (RMS-unit, diagnostic)
-    peak_p95_db: float             # per-chunk |x|.max() の 95%ile (peak-unit)
-    suggested_threshold_db: float  # = peak_p95_db + PEAK_SAFETY_MARGIN_DB
-    danger_zone: tuple[float, float]  # floor ± 5 (RMS-unit diagnostic)
+    noise_floor_db: float                # RMS p25 (RMS-unit, diagnostic)
+    noise_rms_p95_db: float              # RMS p95 (RMS-unit, diagnostic)
+    peak_p95_db: float                   # per-chunk |x|.max() の 95%ile (peak-unit)
+    suggested_threshold_db: float        # = peak_p95_db + peak_safety_margin_db (default: PEAK_SAFETY_MARGIN_DB = 6.0)
+    suggested_engine_min_rms_dbfs: float # = noise_rms_p95_db + engine_min_rms_margin_db (#292)
+    danger_zone: tuple[float, float]     # floor ± 5 (RMS-unit diagnostic)
     sample_count: int
     duration_s: float
 ```
@@ -606,6 +608,9 @@ def analyze_noise_samples(
     samples_db: Sequence[float] | np.ndarray,
     peak_samples_db: Sequence[float] | np.ndarray,
     sample_rate_hz: float = 10.0,
+    *,
+    engine_min_rms_margin_db: float = ENGINE_MIN_RMS_SAFETY_MARGIN_DB,
+    peak_safety_margin_db: float = PEAK_SAFETY_MARGIN_DB,
 ) -> NoiseAnalysis:
 ```
 
@@ -614,6 +619,8 @@ def analyze_noise_samples(
 | `samples_db` | `Sequence[float]` / `np.ndarray` | chunk RMS の dB 列 (`20*log10(rms(chunk))`) |
 | `peak_samples_db` | `Sequence[float]` / `np.ndarray` | chunk peak の dB 列 (`20*log10(|chunk|.max())`)。`len(peak_samples_db) == len(samples_db)` でなければならない |
 | `sample_rate_hz` | `float` | chunk 取得レート (`duration_s` の計算用) |
+| `engine_min_rms_margin_db` | `float` (keyword-only) | `suggested_engine_min_rms_dbfs = noise_rms_p95_db + engine_min_rms_margin_db` (RMS-unit、[#292] EnergyGate)。default `6.0`、CLI `--engine-min-rms-margin` |
+| `peak_safety_margin_db` | `float` (keyword-only) | `suggested_threshold_db = peak_p95_db + peak_safety_margin_db` (peak-unit、NoiseGate)。default `PEAK_SAFETY_MARGIN_DB = 6.0`、**負値も valid** (高 SNR studio mic 向け、AT4040 等)。CLI `--noise-gate-margin` ([#327]) |
 
 **例外**:
 - `ValueError` — `samples_db` / `peak_samples_db` が空、長さ不一致、または `sample_rate_hz <= 0`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -106,6 +106,7 @@ livecap-cli levels --mic 0 --duration 5 --json
 | `--duration` | N 秒後に自動停止（未指定時は Ctrl+C まで） | `None` |
 | `--json` | `NoiseAnalysis` を JSON で stdout に出力（バーチャート抑制） | `False` |
 | `--engine-min-rms-margin` | `suggested_engine_min_rms_dbfs` の safety margin (dB)。`+6` で `noise_rms_p95 + 6` を suggest。 (#292) | `6.0` |
+| `--noise-gate-margin` | `suggested_threshold_db` の peak-unit safety margin (dB)。`6.0` (default) は USB マイク / 一般環境向け、studio コンデンサーマイク (AT4040 等、self-noise <15 dBA) は `2` ~ `-5` 程度。**負値も valid** (peak_p95 が既に conservative な場合 threshold を更に下げる)。 (#327) | `6.0` |
 
 ### 出力例（対話モード）
 

--- a/livecap_cli/audio/analysis.py
+++ b/livecap_cli/audio/analysis.py
@@ -66,8 +66,11 @@ class NoiseAnalysis:
         peak_p95_db: per-chunk ``|x|.max()`` の 95%ile (peak-unit)。
             ``suggested_threshold_db`` の計算基準。NoiseGate envelope
             follower の単位と一致する。
-        suggested_threshold_db: ``peak_p95_db + PEAK_SAFETY_MARGIN_DB``。
-            NoiseGate の ``threshold_db`` にそのまま渡せる値。
+        suggested_threshold_db: ``peak_p95_db + peak_safety_margin_db``
+            (default: :data:`PEAK_SAFETY_MARGIN_DB` = ``6.0``)。NoiseGate の
+            ``threshold_db`` にそのまま渡せる値。Issue [#327] で user-tunable に
+            (高 SNR studio mic 向けに負値も許容、CLI
+            ``levels --noise-gate-margin``)。
         suggested_engine_min_rms_dbfs:
             ``noise_rms_p95_db + engine_min_rms_margin_db``。
             ``StreamTranscriber.engine_min_rms_dbfs`` に渡せる値
@@ -97,6 +100,7 @@ def analyze_noise_samples(
     sample_rate_hz: float = 10.0,
     *,
     engine_min_rms_margin_db: float = ENGINE_MIN_RMS_SAFETY_MARGIN_DB,
+    peak_safety_margin_db: float = PEAK_SAFETY_MARGIN_DB,
 ) -> NoiseAnalysis:
     """ノイズ測定サンプル列から推奨閾値を計算する。
 
@@ -115,6 +119,13 @@ def analyze_noise_samples(
         engine_min_rms_margin_db: ``suggested_engine_min_rms_dbfs`` 計算用
             の safety margin (dB)。default は :data:`ENGINE_MIN_RMS_SAFETY_MARGIN_DB`。
             user が任意に変更可能 (CLI ``--engine-min-rms-margin``)。
+        peak_safety_margin_db: ``suggested_threshold_db`` 計算用の safety
+            margin (dB、peak-unit)。default は :data:`PEAK_SAFETY_MARGIN_DB`
+            (=``6.0``)。Issue [#327] で user-tunable 化 (CLI
+            ``levels --noise-gate-margin``)。高 SNR studio mic
+            (AT4040、self-noise <15 dBA) では負値も valid
+            (``peak_p95`` が既に conservative のため margin を引いて
+            threshold を更に下げる)。
 
     Returns:
         NoiseAnalysis: 分析結果 (``suggested_threshold_db`` は peak ベース、
@@ -146,7 +157,7 @@ def analyze_noise_samples(
         noise_floor_db=noise_floor,
         noise_rms_p95_db=noise_rms_p95,
         peak_p95_db=peak_p95,
-        suggested_threshold_db=peak_p95 + PEAK_SAFETY_MARGIN_DB,
+        suggested_threshold_db=peak_p95 + peak_safety_margin_db,
         suggested_engine_min_rms_dbfs=noise_rms_p95 + engine_min_rms_margin_db,
         danger_zone=(noise_floor - 5.0, noise_floor + 5.0),
         sample_count=int(samples.size),

--- a/livecap_cli/cli.py
+++ b/livecap_cli/cli.py
@@ -276,11 +276,17 @@ def cmd_levels(args: argparse.Namespace) -> int:
                 if getattr(args, "engine_min_rms_margin", None) is not None
                 else ENGINE_MIN_RMS_SAFETY_MARGIN_DB
             )
+            peak_margin = (
+                args.noise_gate_margin
+                if getattr(args, "noise_gate_margin", None) is not None
+                else PEAK_SAFETY_MARGIN_DB
+            )
             analysis = analyze_noise_samples(
                 all_rms_levels,
                 all_peak_levels,
                 sample_rate_hz=sample_rate_hz,
                 engine_min_rms_margin_db=engine_margin,
+                peak_safety_margin_db=peak_margin,
             )
 
             if args.json:
@@ -304,7 +310,7 @@ def cmd_levels(args: argparse.Namespace) -> int:
                 print(
                     f"Suggested --noise-gate-threshold: "
                     f"{analysis.suggested_threshold_db:.0f} dB "
-                    f"(= peak_p95 + {PEAK_SAFETY_MARGIN_DB:g}; "
+                    f"(= peak_p95 + {peak_margin:g}; "
                     f"per-sample peak unit)",
                     file=sys.stderr,
                 )
@@ -784,6 +790,19 @@ def main(argv: list[str] | None = None) -> int:
             "Safety margin (dB) for suggested_engine_min_rms_dbfs "
             "(#292 EnergyGate). "
             "Default: 6.0. Larger value = more aggressive engine-input gate."
+        ),
+    )
+    levels_parser.add_argument(
+        "--noise-gate-margin",
+        type=float,
+        default=None,
+        help=(
+            "Safety margin (dB) for suggested_threshold_db = peak_p95 + margin "
+            "(NoiseGate, peak unit; Issue #327). "
+            "Default: 6.0 (calibrated for USB mics / general environments). "
+            "Smaller value (e.g., 2) for high-SNR mics (AT4040, SM7B). "
+            "Negative values are allowed (e.g., -5 for studio condenser mics "
+            "where peak_p95 is already conservative, ~-60 dB)."
         ),
     )
     levels_parser.set_defaults(func=cmd_levels)

--- a/tests/audio/test_analysis.py
+++ b/tests/audio/test_analysis.py
@@ -173,6 +173,56 @@ class TestNoiseAnalysisEngineMinRms:
         )
 
 
+class TestNoiseAnalysisPeakSafetyMargin:
+    """Issue #327: NoiseAnalysis.suggested_threshold_db と peak_safety_margin_db kwarg。
+
+    `analyze_noise_samples(peak_safety_margin_db=...)` で hardcoded `+6 dB`
+    を user-tunable に。AT4040 等 self-noise <15 dBA の studio コンデンサー
+    マイクで負値を渡せることが motivation (peak_p95 ≈ -60 dB は既に
+    conservative、user は更に低い threshold を望む)。
+    """
+
+    def test_default_peak_margin_unchanged(self):
+        """default 省略時は既存挙動 (peak_p95 + PEAK_SAFETY_MARGIN_DB = 6.0)
+        と bit-identical (backward compat ではなく sensible default の確認)。"""
+        rms = [-50.0] * 10
+        peaks = [-40.0] * 10
+        result = analyze_noise_samples(rms, peaks)
+        assert result.suggested_threshold_db == pytest.approx(
+            result.peak_p95_db + PEAK_SAFETY_MARGIN_DB
+        )
+        # default = 6.0
+        assert result.suggested_threshold_db == pytest.approx(-40.0 + 6.0)
+
+    def test_custom_peak_margin_kwarg(self):
+        """peak_safety_margin_db を user 任意に変更可能
+        (typical USB mic, margin=3 で suggested = peak_p95 + 3)。"""
+        rms = [-50.0] * 10
+        peaks = [-40.0] * 10
+        result = analyze_noise_samples(
+            rms, peaks, peak_safety_margin_db=3.0
+        )
+        assert result.suggested_threshold_db == pytest.approx(
+            result.peak_p95_db + 3.0
+        )
+        assert result.suggested_threshold_db == pytest.approx(-40.0 + 3.0)
+
+    def test_negative_peak_margin_at4040_case(self):
+        """AT4040 case: 負 margin (peak_p95 - 5) で studio mic 対応。
+
+        Issue #327 motivation: AT4040 (self-noise 12 dBA SPL) で peak_p95 が
+        既に conservative (~-60 dB)、user は更に -65 dB (= peak_p95 - 5)
+        の threshold を望む。
+        """
+        rms = [-70.0] * 10
+        peaks = [-60.0] * 10  # AT4040 相当
+        result = analyze_noise_samples(
+            rms, peaks, peak_safety_margin_db=-5.0
+        )
+        assert result.suggested_threshold_db == pytest.approx(-60.0 - 5.0)
+        # → -65 dB が得られる、user 希望と一致
+
+
 class TestSegmentEnergyDbfs:
     """#292: _segment_energy_dbfs の 4 metric ごとの動作。"""
 

--- a/tests/core/cli/test_cli.py
+++ b/tests/core/cli/test_cli.py
@@ -166,6 +166,51 @@ class TestCLINoiseGateOptions:
         assert "--duration" in help_text
 
 
+class TestNoiseGateMarginFlag:
+    """Issue #327: `levels --noise-gate-margin` flag が parse + help に出る。
+
+    `analyze_noise_samples(peak_safety_margin_db=...)` の unit test は
+    `tests/audio/test_analysis.py::TestNoiseAnalysisPeakSafetyMargin` で
+    cover 済。本 test では CLI 層の flag parse + help text のみを pin。
+    """
+
+    def test_levels_help_lists_noise_gate_margin(self) -> None:
+        """`levels --help` に `--noise-gate-margin` の説明が含まれる。"""
+        import io
+        import contextlib
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            try:
+                cli.main(["levels", "--help"])
+            except SystemExit:
+                pass
+        help_text = buf.getvalue()
+        assert "--noise-gate-margin" in help_text
+        # help 文字列の重要 keyword (AT4040 / 負値許容 / NoiseGate)
+        assert "AT4040" in help_text or "high-SNR" in help_text
+        assert "Negative" in help_text or "negative" in help_text
+
+    def test_levels_parses_noise_gate_margin_negative(self) -> None:
+        """`levels --noise-gate-margin -5.0` が argparse で受領される
+        (AT4040 case の負値も valid)。"""
+        import argparse
+        from livecap_cli import cli as cli_mod
+
+        # main() の parse まで到達するパターン。levels は実際には
+        # MicrophoneSource を要するため execute 直前で止める。
+        # argparse 単体テストの代替として `levels --help` で flag 存在を pin
+        # しているため、ここでは parse の最小確認のみ。
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers(dest="command")
+        # 実 cli.py を直接 invoke せずに、levels の add_argument が
+        # 負値の float を受領できることを duck-test
+        sub_parser = sub.add_parser("levels")
+        sub_parser.add_argument("--noise-gate-margin", type=float, default=None)
+        args = parser.parse_args(["levels", "--noise-gate-margin", "-5.0"])
+        assert args.noise_gate_margin == -5.0
+
+
 class TestLevelsBehavior:
     """levels コマンドの E2E 挙動テスト (Issue #280 C-4)。
 

--- a/tests/core/cli/test_cli.py
+++ b/tests/core/cli/test_cli.py
@@ -191,24 +191,69 @@ class TestNoiseGateMarginFlag:
         assert "AT4040" in help_text or "high-SNR" in help_text
         assert "Negative" in help_text or "negative" in help_text
 
-    def test_levels_parses_noise_gate_margin_negative(self) -> None:
-        """`levels --noise-gate-margin -5.0` が argparse で受領される
-        (AT4040 case の負値も valid)。"""
-        import argparse
-        from livecap_cli import cli as cli_mod
+    def test_levels_with_negative_margin_outputs_correct_threshold(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """`levels --noise-gate-margin -5 --json` が実 CLI 経路で
+        `suggested_threshold_db = peak_p95_db - 5` を出力 (AT4040 case)。
 
-        # main() の parse まで到達するパターン。levels は実際には
-        # MicrophoneSource を要するため execute 直前で止める。
-        # argparse 単体テストの代替として `levels --help` で flag 存在を pin
-        # しているため、ここでは parse の最小確認のみ。
-        parser = argparse.ArgumentParser()
-        sub = parser.add_subparsers(dest="command")
-        # 実 cli.py を直接 invoke せずに、levels の add_argument が
-        # 負値の float を受領できることを duck-test
-        sub_parser = sub.add_parser("levels")
-        sub_parser.add_argument("--noise-gate-margin", type=float, default=None)
-        args = parser.parse_args(["levels", "--noise-gate-margin", "-5.0"])
-        assert args.noise_gate_margin == -5.0
+        codex-review #328 1st round LOW 対応: 旧 test は独自 argparse を
+        作っていたため実 CLI の `--noise-gate-margin` が消えても通る pin に
+        なっていなかった。`TestLevelsBehavior._install_fake_mic` の precedent
+        を流用して実 `cli.main(["levels", ...])` 経路を通す形に修正、実装側の
+        flag が壊れた場合に確実に CI で検出する。
+        """
+        import json
+
+        TestLevelsBehavior._install_fake_mic(monkeypatch)
+
+        result = cli.main(
+            [
+                "levels",
+                "--mic", "0",
+                "--duration", "0.3",
+                "--json",
+                "--noise-gate-margin", "-5",
+            ]
+        )
+        captured = capsys.readouterr()
+
+        assert result == 0
+        data = json.loads(captured.out)
+
+        # AT4040 case の核心: peak_p95 - 5 が suggested_threshold_db に反映
+        assert data["suggested_threshold_db"] == pytest.approx(
+            data["peak_p95_db"] - 5.0
+        )
+
+    def test_levels_default_margin_unchanged_when_flag_omitted(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """`--noise-gate-margin` 省略時は既存挙動 (`+6`) と bit-identical。
+
+        codex-review #328 1st round LOW 対応の補完: default 値変更がなく
+        既存呼び出しと完全に互換であることを実 CLI 経路で確認。
+        """
+        import json
+
+        TestLevelsBehavior._install_fake_mic(monkeypatch)
+
+        result = cli.main(
+            ["levels", "--mic", "0", "--duration", "0.3", "--json"]
+        )
+        captured = capsys.readouterr()
+
+        assert result == 0
+        data = json.loads(captured.out)
+
+        # default: suggested = peak_p95 + 6 (PEAK_SAFETY_MARGIN_DB)
+        assert data["suggested_threshold_db"] == pytest.approx(
+            data["peak_p95_db"] + 6.0
+        )
 
 
 class TestLevelsBehavior:


### PR DESCRIPTION
## Summary

[Issue #327](https://github.com/Mega-Gorilla/livecap-cli/issues/327): `PEAK_SAFETY_MARGIN_DB` (hardcoded `6.0`) を user-tunable に。`engine_min_rms_margin_db` (#292) と並列の API 対称性回復。

- **`analyze_noise_samples(peak_safety_margin_db=...)`** keyword 引数追加 (default = 6.0、既存呼び出しは bit-identical)
- **CLI `levels --noise-gate-margin <dB>`** flag 追加 (負値 valid、AT4040 等 studio mic 対応)
- **Tests +5 件** (合計 **717 passed**、退行ゼロ)
- **Migration**: 既存呼び出し / CLI workflow 完全に bit-identical、新 flag は opt-in

Closes #327

## Motivation — AT4040 case

Audio-Technica AT4040 (self-noise 12 dBA SPL、XLR via Roland Rubix 22) で:

| 値 | 旧 hardcoded `+6` | User 希望 |
|---|---|---|
| `peak_p95` | -59.6 dB | -59.6 dB |
| `suggested_threshold_db` | **-53.6 dB** (= peak_p95 + 6) | **-65 dB** (= peak_p95 - 5.4) |

→ Hardcoded `+6 dB` では届かず、user は自動 calibration を諦めて `--noise-gate-threshold -65` を手入力していた。負 margin を許容する設計が必要。

## Scope (user 判断、選択肢 1 採用)

3 つの実装範囲を検討:

| 選択肢 | 内容 | 採用 |
|---|---|---|
| **1** | `levels` のみ + `analyze_noise_samples` arg 追加 | ✅ **採用** (最小、既存 workflow 維持、GUI 自動恩恵) |
| 2 | `levels + transcribe` (parse-only flag) | ❌ Anti-pattern: 効かない flag は user 混乱の原因 |
| 3 | `levels + transcribe + auto-calibration` | ⏸ 別 issue (calibration UX 仕様検討は独立、scope creep) |

→ **`transcribe` には触らない**。既存 CLI workflow (levels → 手動 `--noise-gate-threshold` 指定) は完全に維持。

## Changes (file-by-file)

### `livecap_cli/audio/analysis.py`

```python
def analyze_noise_samples(
    samples_db, peak_samples_db, sample_rate_hz: float = 10.0,
    *,
    engine_min_rms_margin_db: float = ENGINE_MIN_RMS_SAFETY_MARGIN_DB,
    peak_safety_margin_db: float = PEAK_SAFETY_MARGIN_DB,  # ← 新規
) -> NoiseAnalysis:
    ...
    return NoiseAnalysis(
        ...,
        suggested_threshold_db=peak_p95 + peak_safety_margin_db,  # ← arg 使用
        ...
    )
```

- keyword-only argument (`engine_min_rms_margin_db` と signature 対称)
- default = `PEAK_SAFETY_MARGIN_DB = 6.0` (sensible calibrated default、compat shim ではない)
- 関数 docstring `Args:` + `NoiseAnalysis.suggested_threshold_db` field docstring 更新

### `livecap_cli/cli.py`

```python
levels_parser.add_argument(
    "--noise-gate-margin",
    type=float,
    default=None,
    help=(
        "Safety margin (dB) for suggested_threshold_db = peak_p95 + margin "
        "(NoiseGate, peak unit; Issue #327). "
        "Default: 6.0 (calibrated for USB mics / general environments). "
        "Smaller value (e.g., 2) for high-SNR mics (AT4040, SM7B). "
        "Negative values are allowed (e.g., -5 for studio condenser mics "
        "where peak_p95 is already conservative, ~-60 dB)."
    ),
)
```

`cmd_levels` handler:
- `peak_margin = args.noise_gate_margin if ... else PEAK_SAFETY_MARGIN_DB`
- `analyze_noise_samples(peak_safety_margin_db=peak_margin)` に pass
- 出力 `(= peak_p95 + {PEAK_SAFETY_MARGIN_DB:g})` を `{peak_margin:g}` に変更 (user value 反映)

### Tests (新 5 件)

**`tests/audio/test_analysis.py::TestNoiseAnalysisPeakSafetyMargin`** (3 件、既存 `TestNoiseAnalysisEngineMinRms` の precedent を mirror):

- `test_default_peak_margin_unchanged`: default 省略時 bit-identical (`peak_p95 + 6`)
- `test_custom_peak_margin_kwarg`: margin=3 で `suggested = peak_p95 + 3`
- `test_negative_peak_margin_at4040_case`: AT4040 用 margin=-5 で `suggested = peak_p95 - 5` (= -65 dB)

**`tests/core/cli/test_cli.py::TestNoiseGateMarginFlag`** (2 件):

- `test_levels_help_lists_noise_gate_margin`: help text に flag + AT4040 / Negative keyword
- `test_levels_parses_noise_gate_margin_negative`: argparse で負値 (-5.0) 受領

### Docs

- `docs/reference/cli.md`: `levels` オプション表に `--noise-gate-margin` 行追加
- `CHANGELOG.md` `[Unreleased] → ### Added`: 新 entry (workflow 例 + AT4040 case)

## Workflow (既存と完全互換)

```pwsh
# AT4040 等 studio mic
livecap-cli levels --mic 0 --duration 10 --noise-gate-margin -5 --json
# → {"suggested_threshold_db": -64.6, ...}
livecap-cli transcribe --realtime --mic 0 --noise-gate --noise-gate-threshold -64.6

# C920 等 USB mic (旧挙動と同じ)
livecap-cli levels --mic 0 --duration 10 --json
# → {"suggested_threshold_db": -15, ...}  (margin = 6.0 default)
```

## Test plan

- [x] **Unit tests** (`tests/audio/test_analysis.py::TestNoiseAnalysisPeakSafetyMargin`): 3 件 pass
- [x] **CLI tests** (`tests/core/cli/test_cli.py::TestNoiseGateMarginFlag`): 2 件 pass
- [x] **Full local regression**: **717 passed** (712 baseline + 新 5 件)、退行ゼロ

## Out of scope (本 PR では行わない)

| Item | 移管先 |
|---|---|
| `transcribe` への flag 追加 + auto-calibration | 別 issue 推奨 (parse-only effectless flag は anti-pattern、calibration UX 仕様検討は独立) |
| `peak_percentile` の引数化 (現状 hardcoded `95`) | 別 issue (issue body Out of scope) |
| `engine_min_rms_margin_db` resolution pattern refactor | 本 PR は新 flag 追加のみ、precedent 触らない |
| GUI 側の UX 改善 | 別 repo ([livecap-gui#344](https://github.com/Mega-Gorilla/livecap-gui/pull/344)) |
| マイクタイプから margin 自動推奨 heuristic | 別 issue |

## Related

- 親 issue: [#327](https://github.com/Mega-Gorilla/livecap-cli/issues/327)
- 起源 PR (GUI 側): [Mega-Gorilla/livecap-gui#344](https://github.com/Mega-Gorilla/livecap-gui/pull/344)
- API 対称性の precedent: livecap-cli #292
- NoiseGate 設計議論: #280 / #281 / #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)
